### PR TITLE
fix: recognize modern CSS-Modules selectors when extracting classes

### DIFF
--- a/.changeset/fix-modern-selector-extraction.md
+++ b/.changeset/fix-modern-selector-extraction.md
@@ -1,0 +1,7 @@
+---
+'check-unused-css': patch
+---
+
+Recognize modern CSS-Modules selector styles when extracting defined classes, eliminating false positives.
+
+Stylesheets using double-dash modifier classes (`.--reversed`), native CSS Nesting (`.root { &.--error {} }`), SCSS-style suffix concatenation under a compound parent (`.root.--variant { &-faded {} }` → `--variant-faded`), and selector-bearing custom at-rules (`@responsive .item[style*="…"] {}`) previously had those classes dropped during extraction. They were then wrongly reported as "used in source but non-existent in CSS", and mis-derived names were reported as "unused". Extraction now handles all of these, while genuinely missing/unused classes are still reported. Responsive-value containers (`@responsive .--size { @value … }`) whose selector is a build-time template are intentionally not treated as defined classes.

--- a/src/__tests__/modernSelectors.test.ts
+++ b/src/__tests__/modernSelectors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from './runCheckUnusedCss.js';
+
+/**
+ * End-to-end guard for the CSS-extraction fixes (feature 005). The fixture uses
+ * every modern selector style that previously produced false positives —
+ * double-dash modifiers, nested `&.--x`, SCSS suffix concat under a compound
+ * parent, and selector-bearing `@responsive` at-rules — all correctly defined
+ * and referenced. None of those must be reported. At the same time the genuine
+ * findings (a referenced-but-missing class, and a defined-but-unused class)
+ * MUST still be reported, proving the fixes do not over-correct.
+ */
+describe('Modern CSS-Modules selectors (feature 005)', () => {
+  const result = runCheckUnusedCss('src/__tests__/withError/ModernSelectors');
+
+  test('reports the genuinely non-existent classes (true positives)', () => {
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      /Found .* classes used in source files but non-existent in CSS/
+    );
+    expect(result.stdout).toMatch(/ModernSelectors\.tsx:\d+:\d+ - \.missing/);
+    expect(result.stdout).toMatch(
+      /ModernSelectors\.tsx:\d+:\d+ - \.alsoMissing/
+    );
+  });
+
+  test('reports the genuinely unused class (true positive)', () => {
+    expect(result.stdout).toMatch(
+      /ModernSelectors\.module\.css:\d+:\d+ - \.actuallyUnused/
+    );
+  });
+
+  test('does NOT report any defined modern-selector class as a false positive', () => {
+    const falsePositiveClasses = [
+      // nested `&.--modifier`
+      '--reversed',
+      '--error',
+      // SCSS suffix concat under a compound parent
+      '--variant',
+      '--variant-faded',
+      '--variant-outline',
+      // selector-bearing @responsive at-rules
+      'item',
+      '--hidden',
+      '--visibility',
+      // the wrong name the old code would have derived for Badge-style concat
+      'root-faded',
+    ];
+
+    for (const className of falsePositiveClasses) {
+      // Reported lines look like `... - .<className>`; assert none appears.
+      const reported = new RegExp(
+        `- \\.${className.replace(/[-]/g, '\\-')}(\\s|$)`,
+        'm'
+      );
+      expect(result.stdout).not.toMatch(reported);
+    }
+  });
+});

--- a/src/__tests__/withError/ModernSelectors/ModernSelectors.module.css
+++ b/src/__tests__/withError/ModernSelectors/ModernSelectors.module.css
@@ -1,0 +1,37 @@
+.root {
+	display: inline-flex;
+
+	&.--reversed {
+		flex-direction: row-reverse;
+	}
+
+	&.--error {
+		color: red;
+	}
+}
+
+.root.--variant {
+	&-faded {
+		background: #eee;
+	}
+
+	&-outline {
+		background: none;
+	}
+}
+
+@responsive .item[style*="--grid-area"] {
+	display: block;
+}
+
+@responsive .--hidden {
+	display: none;
+
+	&.--visibility {
+		visibility: hidden;
+	}
+}
+
+.actuallyUnused {
+	color: blue;
+}

--- a/src/__tests__/withError/ModernSelectors/ModernSelectors.tsx
+++ b/src/__tests__/withError/ModernSelectors/ModernSelectors.tsx
@@ -1,0 +1,29 @@
+import styles from './ModernSelectors.module.css';
+
+// Exercises the modern selector styles supported by the extractor, all via
+// STATIC access (so the non-existent check runs — it skips files with dynamic
+// access). Classes referenced here are DEFINED in the CSS and must NOT be
+// reported:
+//  - nested `&.--modifier` (root, --reversed, --error)
+//  - SCSS suffix concat under a compound parent (--variant, --variant-faded/outline)
+//  - selector-bearing `@responsive` at-rules (item, --hidden, --visibility)
+// `.missing` / `.alsoMissing` are NOT in the CSS — genuine "used but
+// non-existent" findings that must survive the extractor fixes.
+// `.actuallyUnused` is defined but never referenced — a genuine "unused" finding.
+export const ModernSelectors = () => (
+  <div
+    className={[
+      styles.root,
+      styles['--reversed'],
+      styles['--error'],
+      styles['--variant'],
+      styles['--variant-faded'],
+      styles['--variant-outline'],
+      styles.item,
+      styles['--hidden'],
+      styles['--visibility'],
+      styles.missing,
+      styles.alsoMissing,
+    ].join(' ')}
+  />
+);

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -101,9 +101,31 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual([]);
     });
 
+    test('A4b: statement-form @value does not make the selector a template', () => {
+      // `@value foo: 1;` is a CSS-Modules variable, not a template container, so
+      // `.root` is still extracted as a real class.
+      expect(
+        extractSorted('@responsive .root { @value foo: 1; color: red; }')
+      ).toEqual(sorted(['root']));
+    });
+
     test('A5: @responsive with a condition (no class) invents nothing', () => {
       expect(
         extractSorted('@responsive (min-width: 1px) { color: red; }')
+      ).toEqual([]);
+    });
+
+    test('A5b: @responsive condition with a decimal invents nothing', () => {
+      expect(
+        extractSorted('@responsive (min-width: 1.5rem) { color: red; }')
+      ).toEqual([]);
+    });
+
+    test('A5c: @responsive condition containing url() with a dot invents nothing', () => {
+      // The cheap detector may let `url(a.b)` through, but the selector parser
+      // finds no class in a condition, so nothing is invented.
+      expect(
+        extractSorted('@responsive (foo: url(a.b)) { color: red; }')
       ).toEqual([]);
     });
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from 'bun:test';
+import { extractCssClasses } from './extractCssClasses.js';
+
+/**
+ * End-to-end extraction tests that run the REAL pipeline (postcss-scss parse ->
+ * extractClassNamesFromRule -> css-selector-parser) without mocking. These cover
+ * the modern CSS-Modules selector styles that previously produced false positives:
+ * double-dash modifier classes, native CSS Nesting with `&`, SCSS-style suffix
+ * concatenation, and selector-bearing custom at-rules (e.g. `@responsive`).
+ *
+ * Sorting both sides keeps assertions order-independent (extraction order is an
+ * implementation detail; the SET of defined classes is what matters).
+ */
+const extractSorted = (css: string): string[] =>
+  [...extractCssClasses(css)].sort();
+const sorted = (classNames: string[]): string[] => [...classNames].sort();
+
+describe('extractCssClasses (integration, real pipeline)', () => {
+  describe('double-dash modifier classes (US1)', () => {
+    test('N1: standalone double-dash modifier', () => {
+      expect(extractSorted('.--selected { color: red; }')).toEqual(
+        sorted(['--selected'])
+      );
+    });
+
+    test('N2: compound double-dash modifier', () => {
+      expect(extractSorted('.root.--variant { color: red; }')).toEqual(
+        sorted(['root', '--variant'])
+      );
+    });
+
+    test('N3: double-dash inside :not() argument', () => {
+      expect(
+        extractSorted('.--actionable:not(.--selected) { color: red; }')
+      ).toEqual(sorted(['--actionable', '--selected']));
+    });
+  });
+
+  describe('native CSS nesting with & (US2)', () => {
+    test('N4: compound modifier joined to parent (&.--reversed)', () => {
+      expect(
+        extractSorted('.root { color: red; &.--reversed { color: blue; } }')
+      ).toEqual(sorted(['root', '--reversed']));
+    });
+
+    test('N5: multiple nested modifier blocks', () => {
+      expect(
+        extractSorted('.root { &.--error { color: red; } &.--disabled {} }')
+      ).toEqual(sorted(['root', '--error', '--disabled']));
+    });
+
+    test('N6: deep nesting with descendant then modifier', () => {
+      expect(
+        extractSorted('.root { & .area { &.--visible { color: red; } } }')
+      ).toEqual(sorted(['root', 'area', '--visible']));
+    });
+
+    test('C7 (no regression): descendant nesting still works', () => {
+      expect(extractSorted('.toast { & .icon { color: red; } }')).toEqual(
+        sorted(['toast', 'icon'])
+      );
+    });
+
+    test('C10 (no regression): &.otherClass captures the modifier', () => {
+      expect(
+        extractSorted('.usedClass { &.otherClass { color: red; } }')
+      ).toEqual(sorted(['usedClass', 'otherClass']));
+    });
+  });
+
+  describe('selector-bearing custom at-rules (US3)', () => {
+    test('A1: @responsive selector with attribute matcher', () => {
+      expect(
+        extractSorted(
+          '@responsive .item[style*="--rs-grid-area"] { display: block; }'
+        )
+      ).toEqual(sorted(['item']));
+    });
+
+    test('A2: @responsive selector targeting .root with attribute matcher', () => {
+      expect(
+        extractSorted('@responsive .root[style*="--rs-w-"] { width: 1px; }')
+      ).toEqual(sorted(['root']));
+    });
+
+    test('A3: @responsive @value container is a template (selector skipped) but real nested classes are kept', () => {
+      // `--hidden` is a responsive-value template (reached only via
+      // `responsiveClassNames(s, "--hidden", …)`, never `s["--hidden"]`), so its
+      // selector is NOT extracted. The nested `&.--visibility` IS a real class
+      // (accessed as `s["--visibility"]`) and must still be extracted.
+      expect(
+        extractSorted(
+          '@responsive .--hidden { @value true { display: none; &.--visibility { display: contents; } } }'
+        )
+      ).toEqual(sorted(['--visibility']));
+    });
+
+    test('A4: @responsive @value container selector is skipped (build-time template)', () => {
+      expect(
+        extractSorted('@responsive .--size { @value small { color: red; } }')
+      ).toEqual([]);
+    });
+
+    test('A5: @responsive with a condition (no class) invents nothing', () => {
+      expect(
+        extractSorted('@responsive (min-width: 1px) { color: red; }')
+      ).toEqual([]);
+    });
+
+    test('A6 (no regression): class inside a standard @media rule', () => {
+      expect(
+        extractSorted('@media (--bp) { .item[style*="x"] { color: red; } }')
+      ).toEqual(sorted(['item']));
+    });
+  });
+
+  describe('SCSS suffix concatenation under a compound parent (US4)', () => {
+    test('T1: &-suffix joins to the last class of `.root.--variant`', () => {
+      expect(
+        extractSorted(
+          '.root.--variant { &-faded { color: red; } &-outline { color: blue; } }'
+        )
+      ).toEqual(
+        sorted(['root', '--variant', '--variant-faded', '--variant-outline'])
+      );
+    });
+
+    test('T1: does not derive the wrong `root-faded` name', () => {
+      expect(extractCssClasses('.root.--variant { &-faded {} }')).not.toContain(
+        'root-faded'
+      );
+    });
+
+    test('T2: &-size suffixes join to `.root.--size`', () => {
+      expect(
+        extractSorted('.root.--size { &-small {} &-medium {} &-large {} }')
+      ).toEqual(
+        sorted([
+          'root',
+          '--size',
+          '--size-small',
+          '--size-medium',
+          '--size-large',
+        ])
+      );
+    });
+
+    test('T3: compound parent with a single trailing modifier', () => {
+      expect(extractSorted('.root.--color-positive { color: red; }')).toEqual(
+        sorted(['root', '--color-positive'])
+      );
+    });
+
+    test('T4: &-suffix ignores a dot-prefixed token in the parent attribute value', () => {
+      // The `.foo` inside the attribute value must not be mistaken for the
+      // parent class; `&-bar` joins to `item`, yielding `item-bar`.
+      expect(
+        extractSorted('.item[style*=".foo"] { &-bar { color: red; } }')
+      ).toEqual(sorted(['item', 'item-bar']));
+    });
+  });
+
+  describe('comprehensive: all patterns combined', () => {
+    test('extracts the full defined-class set from a mixed stylesheet', () => {
+      const css = `
+        .root {
+          display: flex;
+          &.--reversed { flex-direction: row-reverse; }
+          & .icon { width: 16px; }
+        }
+
+        .root.--variant {
+          &-faded { background: #eee; }
+          &-outline { background: none; }
+        }
+
+        @responsive .item[style*="--grid-area"] {
+          display: block;
+        }
+
+        @responsive .--display {
+          @value true {
+            display: none;
+            &.--visibility { visibility: hidden; }
+          }
+        }
+
+        .plain { color: red; }
+      `;
+
+      // `--display` is a responsive-value template (has @value children) and is
+      // intentionally NOT extracted; the nested `&.--visibility` IS a real class.
+      expect(extractSorted(css)).toEqual(
+        sorted([
+          'root',
+          '--reversed',
+          'icon',
+          '--variant',
+          '--variant-faded',
+          '--variant-outline',
+          'item',
+          '--visibility',
+          'plain',
+        ])
+      );
+    });
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
@@ -1,7 +1,11 @@
 import postcssScss from 'postcss-scss';
 import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
-import { extractClassNamesFromRule } from './utils/extractClassNamesFromRule.js';
+import {
+  extractClassNamesFromAtRule,
+  extractClassNamesFromRule,
+} from './utils/extractClassNamesFromRule.js';
 import { extractComposedClasses } from './utils/extractComposedClasses.js';
+import { isSelectorBearingAtRule } from './utils/isSelectorBearingAtRule.js';
 
 export type CssClassInfo = {
   className: string;
@@ -27,6 +31,24 @@ export const extractCssClasses = (cssContent: string): string[] => {
 
     const ruleClassNames = extractClassNamesFromRule(rule);
     for (const className of ruleClassNames) {
+      classNames.add(className);
+    }
+  });
+
+  // Selector-bearing custom at-rules (e.g. `@responsive .item[style*="…"]`)
+  // hold their selector in `params` with no inner rule node, so `walkRules`
+  // never visits them. Extract their classes from the at-rule params.
+  root.walkAtRules((atRule) => {
+    if (atRule.source?.start && ignoredLines.has(atRule.source.start.line)) {
+      return;
+    }
+
+    if (!isSelectorBearingAtRule(atRule)) {
+      return;
+    }
+
+    const atRuleClassNames = extractClassNamesFromAtRule(atRule);
+    for (const className of atRuleClassNames) {
       classNames.add(className);
     }
   });
@@ -65,6 +87,31 @@ export const extractCssClassesWithLocations = (
           className,
           line: rule.source.start.line,
           column: rule.source.start.column,
+        });
+      }
+    }
+  });
+
+  // Selector-bearing custom at-rules (e.g. `@responsive .item[style*="…"]`)
+  // hold their selector in `params` with no inner rule node, so `walkRules`
+  // never visits them. Extract their classes from the at-rule params.
+  root.walkAtRules((atRule) => {
+    if (atRule.source?.start && ignoredLines.has(atRule.source.start.line)) {
+      return;
+    }
+
+    if (!isSelectorBearingAtRule(atRule)) {
+      return;
+    }
+
+    const atRuleClassNames = extractClassNamesFromAtRule(atRule);
+    for (const className of atRuleClassNames) {
+      // Only keep the first occurrence of each class
+      if (!classInfoMap.has(className) && atRule.source?.start) {
+        classInfoMap.set(className, {
+          className,
+          line: atRule.source.start.line,
+          column: atRule.source.start.column,
         });
       }
     }

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.test.ts
@@ -161,20 +161,36 @@ describe('extractClassNamesFromRule', () => {
   });
 
   describe('should handle malformed selectors gracefully', () => {
-    test('returns empty array for invalid selectors', () => {
+    // Non-strict parsing tolerates truncated attribute/pseudo selectors and
+    // recovers the recognizable class names rather than dropping the whole
+    // rule. For an unused-CSS analyzer, extracting `class` (and thus marking it
+    // used) is safer than silently losing the definition.
+    test('extracts the recoverable class from a truncated attribute selector', () => {
       const rule = createMockRule('.class[invalid');
       const result = extractClassNamesFromRule(rule);
-      expect(result).toEqual([]);
+      expect(result).toEqual(['class']);
     });
 
-    test('returns empty array for unclosed brackets', () => {
+    test('extracts recoverable classes from an unclosed pseudo-argument', () => {
       const rule = createMockRule('.class:not(.other');
       const result = extractClassNamesFromRule(rule);
-      expect(result).toEqual([]);
+      expect(result).toEqual(['class', 'other']);
     });
 
     test('returns empty array for malformed pseudo-selectors', () => {
       const rule = createMockRule('.class::');
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array for an empty selector', () => {
+      const rule = createMockRule('');
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual([]);
+    });
+
+    test('returns empty array for a whitespace-only selector', () => {
+      const rule = createMockRule('   ');
       const result = extractClassNamesFromRule(rule);
       expect(result).toEqual([]);
     });
@@ -301,6 +317,35 @@ describe('extractClassNamesFromRule', () => {
       const rule = createMockRule('&Suffix');
       const result = extractClassNamesFromRule(rule);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('should handle double-dash modifier classes', () => {
+    test('extracts a standalone double-dash class', () => {
+      const rule = createMockRule('.--selected');
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual(['--selected']);
+    });
+
+    test('extracts both classes from a compound double-dash selector', () => {
+      const rule = createMockRule('.root.--variant');
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual(['root', '--variant']);
+    });
+
+    test('extracts double-dash classes from a :not() argument', () => {
+      const rule = createMockRule('.--actionable:not(.--selected)');
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual(['--actionable', '--selected']);
+    });
+
+    test('resolves a nested double-dash modifier joined to the parent', () => {
+      const rule = createMockRule('&.--reversed', {
+        type: 'rule',
+        selector: '.root',
+      });
+      const result = extractClassNamesFromRule(rule);
+      expect(result).toEqual(['--reversed']);
     });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -1,5 +1,5 @@
 import { createParser, type Parser } from 'css-selector-parser';
-import type { Rule } from 'postcss';
+import type { AtRule, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
 import { findClassNamesInSelector } from './findClassNamesInSelector.js';
 import {
@@ -7,14 +7,25 @@ import {
   resolveAmpersandSelector,
 } from './resolveAmpersandSelector.js';
 
-const parseSelector: Parser = createParser();
+/**
+ * Non-strict mode lets the parser accept identifiers that start with two
+ * hyphens (e.g. `.--reversed`, `.root.--variant`) — a common CSS-Modules
+ * modifier convention that strict mode rejects, which would otherwise make the
+ * `catch` below silently drop the whole rule. Non-strict mode is also more
+ * tolerant of truncated selectors, extracting the recognizable class names
+ * instead of discarding the rule; for an unused-CSS analyzer, erring toward
+ * "this class is used" is safer than losing a definition.
+ */
+const parseSelector: Parser = createParser({ strict: false });
 
-export const extractClassNamesFromRule = (rule: Rule): string[] => {
+/**
+ * Resolve a raw selector string (already ampersand-resolved against its parent)
+ * into the class names it defines. Returns an empty array if the selector
+ * cannot be parsed at all.
+ */
+const extractClassNamesFromSelector = (selector: string): string[] => {
   try {
-    const parentClassName = getParentClassName(rule);
-    const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
-
-    const processedSelector = clearGlobalSelectors(resolved);
+    const processedSelector = clearGlobalSelectors(selector);
     const parsed = parseSelector(processedSelector);
 
     if (Array.isArray(parsed)) {
@@ -26,3 +37,22 @@ export const extractClassNamesFromRule = (rule: Rule): string[] => {
     return [];
   }
 };
+
+export const extractClassNamesFromRule = (rule: Rule): string[] => {
+  const parentClassName = getParentClassName(rule);
+  const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
+
+  return extractClassNamesFromSelector(resolved);
+};
+
+/**
+ * Extract class names from a selector-bearing custom at-rule, e.g.
+ * `@responsive .item[style*="…"] { … }`. PostCSS parses such an at-rule with
+ * the selector held in `params` (and declarations directly inside the at-rule,
+ * with no inner rule node), so `walkRules` never sees it. Here we treat the
+ * at-rule's `params` as the selector. The caller is responsible for only
+ * passing at-rules whose params are a selector (not a media/supports-style
+ * condition); a params string with no class token yields an empty array.
+ */
+export const extractClassNamesFromAtRule = (atRule: AtRule): string[] =>
+  extractClassNamesFromSelector(atRule.params);

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import postcssScss from 'postcss-scss';
+import { isSelectorBearingAtRule } from './isSelectorBearingAtRule.js';
+
+/** Parse a single at-rule from CSS and hand it to the predicate. */
+const firstAtRule = (css: string): boolean => {
+  const root = postcssScss.parse(css);
+  let result = false;
+  let found = false;
+  root.walkAtRules((atRule) => {
+    if (found) return;
+    found = true;
+    result = isSelectorBearingAtRule(atRule);
+  });
+  if (!found) throw new Error('No at-rule found in CSS');
+  return result;
+};
+
+describe('isSelectorBearingAtRule', () => {
+  describe('selector-bearing custom at-rules (true)', () => {
+    test('custom at-rule with a class selector', () => {
+      expect(firstAtRule('@responsive .item { display: block; }')).toBe(true);
+    });
+
+    test('custom at-rule with a class + attribute selector', () => {
+      expect(
+        firstAtRule('@responsive .item[style*="--x"] { display: block; }')
+      ).toBe(true);
+    });
+
+    test('custom at-rule with a double-dash class selector', () => {
+      expect(firstAtRule('@responsive .--hidden { display: none; }')).toBe(
+        true
+      );
+    });
+
+    test('custom at-rule whose body is a @variable block', () => {
+      expect(firstAtRule('@responsive .root { @variable --x auto; }')).toBe(
+        true
+      );
+    });
+  });
+
+  describe('standard condition/identifier at-rules (false)', () => {
+    test('@media is never selector-bearing', () => {
+      expect(
+        firstAtRule('@media (min-width: 1px) { .x { color: red; } }')
+      ).toBe(false);
+    });
+
+    test('@supports is never selector-bearing', () => {
+      expect(
+        firstAtRule('@supports (display: grid) { .x { color: red; } }')
+      ).toBe(false);
+    });
+
+    test('@container is never selector-bearing', () => {
+      expect(firstAtRule('@container (min-width: 1px) { .x {} }')).toBe(false);
+    });
+
+    test('@keyframes is never selector-bearing', () => {
+      expect(firstAtRule('@keyframes spin { from {} to {} }')).toBe(false);
+    });
+
+    test('@layer is never selector-bearing', () => {
+      expect(firstAtRule('@layer base { .x {} }')).toBe(false);
+    });
+  });
+
+  describe('params without a class token (false)', () => {
+    test('custom at-rule used purely as a condition wrapper', () => {
+      expect(firstAtRule('@responsive (min-width: 1px) { color: red; }')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('responsive-value containers are templates (false)', () => {
+    test('@responsive with @value children is skipped', () => {
+      expect(
+        firstAtRule('@responsive .--size { @value small { color: red; } }')
+      ).toBe(false);
+    });
+
+    test('@responsive with multiple @value children is skipped', () => {
+      expect(
+        firstAtRule(
+          '@responsive .--type { @value literal { width: 1px; } @value unit { width: 2px; } }'
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
@@ -89,5 +89,28 @@ describe('isSelectorBearingAtRule', () => {
         )
       ).toBe(false);
     });
+
+    test('statement-form @value (no block) does NOT make a selector a template', () => {
+      // `@value foo: 1;` is a CSS-Modules variable declaration, not a template
+      // container, so `.root` is still a real selector-bearing class.
+      expect(
+        firstAtRule('@responsive .root { @value foo: 1; color: red; }')
+      ).toBe(true);
+    });
+  });
+
+  describe('condition params with stray dots are not selectors (false)', () => {
+    test('decimal in a condition is not treated as a class', () => {
+      // `.5` / `1.5` — a dot followed by a digit is not a class token.
+      expect(
+        firstAtRule('@responsive (min-width: 1.5rem) { color: red; }')
+      ).toBe(false);
+    });
+
+    test('a dot directly followed by a digit is not a class token', () => {
+      expect(firstAtRule('@responsive (margin: .5em) { color: red; }')).toBe(
+        false
+      );
+    });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
@@ -1,0 +1,67 @@
+import type { AtRule } from 'postcss';
+
+/**
+ * Standard at-rules whose `params` are NOT a selector. Some take a condition
+ * (`@media (min-width: …)`, `@supports (display: grid)`, `@container`), some an
+ * identifier/keyframe-name (`@keyframes spin`, `@layer base`), some nothing or a
+ * URL (`@font-face`, `@page`, `@property`, `@import`, `@charset`). A class token
+ * appearing inside their params (e.g. a selector list under `@scope (.a) to (.b)`)
+ * is part of a condition, not a class definition, so we never treat these as
+ * selector-bearing. Custom CSS-Modules `@value` is excluded for the same reason.
+ */
+const NON_SELECTOR_AT_RULES = new Set([
+  'media',
+  'supports',
+  'container',
+  'layer',
+  'scope',
+  'keyframes',
+  'font-face',
+  'page',
+  'property',
+  'counter-style',
+  'font-feature-values',
+  'import',
+  'charset',
+  'namespace',
+  'document',
+  'value',
+]);
+
+/**
+ * Whether an at-rule's direct children are `@value` blocks. Such an at-rule is a
+ * responsive-value container (e.g. `@responsive .--size { @value small { … } }`):
+ * its selector is a TEMPLATE expanded at build time into `--size-small` etc.,
+ * never referenced literally as `s['--size']` (source reaches it via helpers
+ * like `responsiveClassNames(s, '--size', value)`). Extracting the template name
+ * as a class would produce a false "unused" finding, so these are skipped.
+ * Any real classes nested deeper (e.g. `&.--visibility` inside a `@value` block)
+ * are still picked up by the normal rule walk.
+ */
+const containsValueBlocks = (atRule: AtRule): boolean =>
+  (atRule.nodes ?? []).some(
+    (node) => node.type === 'atrule' && node.name.toLowerCase() === 'value'
+  );
+
+/**
+ * Whether an at-rule's `params` should be treated as a CSS selector defining
+ * classes. True for custom at-rules (e.g. `@responsive .item[style*="…"]`)
+ * whose params contain a class token and whose body is a direct style block;
+ * false for standard condition/identifier at-rules, params with no class token
+ * (e.g. `@responsive (min-width: 1px)`), and responsive-value containers whose
+ * selector is a build-time template (e.g. `@responsive .--size { @value … }`).
+ */
+export const isSelectorBearingAtRule = (atRule: AtRule): boolean => {
+  if (NON_SELECTOR_AT_RULES.has(atRule.name.toLowerCase())) {
+    return false;
+  }
+
+  // A class token is required for the params to define a class. This also
+  // filters out custom at-rules used purely as condition wrappers
+  // (e.g. `@responsive (min-width: 1px)`), which invent no class names.
+  if (!atRule.params.includes('.')) {
+    return false;
+  }
+
+  return !containsValueBlocks(atRule);
+};

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
@@ -1,5 +1,10 @@
 import type { AtRule } from 'postcss';
 
+// Matches a CSS class token, including the `.--modifier` double-dash convention.
+// Used to confirm the params actually define a class rather than merely
+// containing a stray `.` (e.g. a decimal in `(min-width: 1.5rem)` or a URL).
+const CLASS_TOKEN_PATTERN = /\.[-_a-zA-Z]/;
+
 /**
  * Standard at-rules whose `params` are NOT a selector. Some take a condition
  * (`@media (min-width: …)`, `@supports (display: grid)`, `@container`), some an
@@ -29,18 +34,25 @@ const NON_SELECTOR_AT_RULES = new Set([
 ]);
 
 /**
- * Whether an at-rule's direct children are `@value` blocks. Such an at-rule is a
- * responsive-value container (e.g. `@responsive .--size { @value small { … } }`):
+ * Whether an at-rule's direct children include a `@value` BLOCK. Such an at-rule
+ * is a responsive-value container (e.g. `@responsive .--size { @value small { … } }`):
  * its selector is a TEMPLATE expanded at build time into `--size-small` etc.,
  * never referenced literally as `s['--size']` (source reaches it via helpers
  * like `responsiveClassNames(s, '--size', value)`). Extracting the template name
  * as a class would produce a false "unused" finding, so these are skipped.
  * Any real classes nested deeper (e.g. `&.--visibility` inside a `@value` block)
  * are still picked up by the normal rule walk.
+ *
+ * Only block-form `@value` (with a `{ … }` body, i.e. a `nodes` array) signals a
+ * template container. Statement-form `@value foo: 1;` is a CSS-Modules variable
+ * declaration and must NOT cause the selector to be skipped.
  */
 const containsValueBlocks = (atRule: AtRule): boolean =>
   (atRule.nodes ?? []).some(
-    (node) => node.type === 'atrule' && node.name.toLowerCase() === 'value'
+    (node) =>
+      node.type === 'atrule' &&
+      node.name.toLowerCase() === 'value' &&
+      node.nodes !== undefined
   );
 
 /**
@@ -56,10 +68,12 @@ export const isSelectorBearingAtRule = (atRule: AtRule): boolean => {
     return false;
   }
 
-  // A class token is required for the params to define a class. This also
-  // filters out custom at-rules used purely as condition wrappers
-  // (e.g. `@responsive (min-width: 1px)`), which invent no class names.
-  if (!atRule.params.includes('.')) {
+  // An actual class token is required for the params to define a class. A bare
+  // `.includes('.')` is too broad — it matches condition wrappers with decimals
+  // or URLs (e.g. `@responsive (min-width: 1.5rem)`), so match a real class
+  // token instead. This also filters out condition-only custom at-rules, which
+  // invent no class names.
+  if (!CLASS_TOKEN_PATTERN.test(atRule.params)) {
     return false;
   }
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.test.ts
@@ -191,4 +191,83 @@ describe('getParentClassName', () => {
       expect(getParentClassName(rule)).toBe('nested');
     });
   });
+
+  describe('should resolve the last class of a compound parent', () => {
+    // SCSS suffix concatenation (`&-faded`) joins to the IMMEDIATE parent class,
+    // which is the rightmost class token of a compound parent selector. For
+    // `.root.--variant { &-faded { … } }` the resulting class is
+    // `--variant-faded` (matching how source accesses it: `s[`--variant-${x}`]`),
+    // not `root-faded`.
+    test('resolves the last class of `.root.--variant`', () => {
+      const rule = createMockRule('&-faded', {
+        type: 'rule',
+        selector: '.root.--variant',
+      });
+      expect(getParentClassName(rule)).toBe('--variant');
+    });
+
+    test('resolves the last class of `.root.--size`', () => {
+      const rule = createMockRule('&-small', {
+        type: 'rule',
+        selector: '.root.--size',
+      });
+      expect(getParentClassName(rule)).toBe('--size');
+    });
+
+    test('resolves the last class of a three-class compound', () => {
+      const rule = createMockRule('&Suffix', {
+        type: 'rule',
+        selector: '.a.b.c',
+      });
+      expect(getParentClassName(rule)).toBe('c');
+    });
+
+    test('single-class parent is unaffected (last === first)', () => {
+      const rule = createMockRule('&-x', {
+        type: 'rule',
+        selector: '.root',
+      });
+      expect(getParentClassName(rule)).toBe('root');
+    });
+
+    test('single-class parent with pseudo is unaffected', () => {
+      const rule = createMockRule('&-x', {
+        type: 'rule',
+        selector: '.usedClass:hover',
+      });
+      expect(getParentClassName(rule)).toBe('usedClass');
+    });
+
+    test('ignores a dot-prefixed token inside an attribute value', () => {
+      const rule = createMockRule('&-bar', {
+        type: 'rule',
+        selector: '.item[style*=".foo"]',
+      });
+      expect(getParentClassName(rule)).toBe('item');
+    });
+
+    test('ignores a class inside a :not() argument', () => {
+      const rule = createMockRule('&-suffix', {
+        type: 'rule',
+        selector: '.real:not(.fake)',
+      });
+      expect(getParentClassName(rule)).toBe('real');
+    });
+
+    test('uses the last class of the right-most compound in a descendant selector', () => {
+      const rule = createMockRule('&-x', {
+        type: 'rule',
+        selector: '.a .b.c',
+      });
+      expect(getParentClassName(rule)).toBe('c');
+    });
+
+    test('uses the last selector in a selector list', () => {
+      const rule = createMockRule('&-x', {
+        type: 'rule',
+        selector: '.a, .b',
+      });
+      expect(getParentClassName(rule)).toBe('b');
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
@@ -1,6 +1,15 @@
+import {
+  type AstRule,
+  type AstSelector,
+  createParser,
+  type Parser,
+} from 'css-selector-parser';
 import type { Rule } from 'postcss';
+import { clearGlobalSelectors } from './clearGlobalSelectors.js';
 
-const CLASS_NAME_PATTERN = /\.([a-zA-Z_][\w-]*)/;
+// Non-strict mode so double-dash modifier classes (`.--variant`) parse; see the
+// matching note in extractClassNamesFromRule.ts.
+const parseSelector: Parser = createParser({ strict: false });
 
 const getParentRule = (rule: Rule): Rule | null => {
   const { parent } = rule;
@@ -8,6 +17,52 @@ const getParentRule = (rule: Rule): Rule | null => {
     return parent as Rule;
   }
   return null;
+};
+
+/**
+ * Return the last direct class name of a parsed compound (the right-most
+ * `ClassName` in its `items`), ignoring classes that live inside attribute
+ * values or pseudo-class arguments (e.g. `[style*=".foo"]`, `:not(.fake)`).
+ */
+const getLastClassNameOfRule = (rule: AstRule): string | null => {
+  let lastClassName: string | null = null;
+  for (const item of rule.items) {
+    if (item.type === 'ClassName') {
+      lastClassName = item.name;
+    }
+  }
+  return lastClassName;
+};
+
+/**
+ * Return the rightmost (last) class of a selector's right-most compound, or
+ * `null` if it has none. For SCSS suffix concatenation (`&-faded`), the suffix
+ * joins to the IMMEDIATE parent class — the last class of a compound parent like
+ * `.root.--variant` (→ `--variant`), not the first (`root`).
+ *
+ * Parsing (rather than a raw regex) is required so a `.`-prefixed token inside
+ * an attribute value or pseudo-class argument is not mistaken for the parent
+ * class — e.g. `.item[style*=".foo"]` must resolve to `item`, not `foo`.
+ */
+const getLastClassName = (selector: string): string | null => {
+  let parsed: AstSelector;
+  try {
+    parsed = parseSelector(clearGlobalSelectors(selector));
+  } catch {
+    return null;
+  }
+
+  // Use the last selector in a list (`.a, .b` → `.b`), then follow the
+  // descendant/combinator chain to its right-most compound.
+  let rule: AstRule | undefined = parsed.rules.at(-1);
+  if (!rule) {
+    return null;
+  }
+  while (rule.nestedRule) {
+    rule = rule.nestedRule;
+  }
+
+  return getLastClassNameOfRule(rule);
 };
 
 export const getParentClassName = (rule: Rule): string | null => {
@@ -23,12 +78,10 @@ export const getParentClassName = (rule: Rule): string | null => {
       parentRule.selector,
       grandParentClassName
     );
-    const match = resolved.match(CLASS_NAME_PATTERN);
-    return match?.[1] ?? null;
+    return getLastClassName(resolved);
   }
 
-  const match = parentRule.selector.match(CLASS_NAME_PATTERN);
-  return match?.[1] ?? null;
+  return getLastClassName(parentRule.selector);
 };
 
 export const resolveAmpersandSelector = (


### PR DESCRIPTION
## Problem

Running `check-unused-css` against a real design system (`reshaped`) produced **34 false "used but non-existent in CSS"** findings and bogus "unused" entries. Classes that are clearly defined — e.g. `.--reversed` in `Switch.module.css` — were reported as missing. Root cause: the CSS class-**extraction** path didn't understand several modern CSS-Modules selector styles, so it silently dropped those class definitions (and in one case invented a wrong name).

## Root causes (4, all reproduced)

1. **Double-dash classes dropped.** `css-selector-parser` in strict mode throws on identifiers starting with `--` (`.--selected`, `.root.--variant`); the `catch` then returned `[]`, dropping the whole rule.
2. **Compound nested modifiers lost.** `.root { &.--reversed {} }` funnels into the same strict-mode failure (after `&` stripping it becomes `.--reversed`).
3. **SCSS suffix concat derived the wrong name.** `.root.--variant { &-faded {} }` produced `root-faded` (first class of the compound parent) instead of `--variant-faded` (last class) — the name source actually accesses via `` s[`--variant-${variant}`] ``. This created both a false "non-existent" and a false "unused".
4. **Classes inside custom at-rules were invisible.** `@responsive .item[style*="…"] {}` is parsed by postcss as an at-rule with the selector in `params` (no inner rule node), so `walkRules` never saw it.

## Fix (CSS extraction only)

- **`createParser({ strict: false })`** — accept `--`-prefixed identifiers; one change fixes (1) and (2). Non-strict mode also recovers classes from truncated selectors instead of dropping the rule (safer for an unused-CSS checker).
- **Resolve `&`-suffix concat against the LAST class of a compound parent**, derived from the parsed **AST** (so dots inside attribute values / `:not()` args — `.item[style*=".foo"]`, `:not(.fake)` — are not mistaken for the parent class).
- **Walk selector-bearing custom at-rules** and extract their classes, while skipping standard condition/identifier at-rules (`@media`/`@supports`/`@keyframes`/…) and **responsive-value containers** (`@responsive .--size { @value … }`) whose selector is a build-time template.

Genuinely missing or unused classes are **still reported** (verified on `reshaped`: the 5 remaining "non-existent" are real — `Toast .toast`/`.icon`, `Select .option`, `Calendar .row`).

## Tests

- New unit tests per bug category (`extractClassNamesFromRule`, `resolveAmpersandSelector`, `isSelectorBearingAtRule`).
- New real-pipeline integration tests (`extractCssClasses.integration.test.ts`) covering every selector pattern + a comprehensive combined case.
- New end-to-end fixture (`__tests__/withError/ModernSelectors`) proving false positives are gone while true positives (missing + unused) are still reported.
- Two existing "malformed selectors gracefully" assertions updated: truncated `[...`/`:not(...` now recover the recognizable class instead of dropping the rule (documented, intentional). `.class::` and empty selectors still yield `[]`.

Baseline **736 → 786 tests, 0 fail**; `check:all` (format + lint + type + test) green.

## Known follow-up (out of scope)

Correctly extracting `--` classes newly surfaces reshaped's responsive-template base classes (e.g. `--nowrap`, `--direction`) as "unused" — these are reached only via the `responsiveClassNames(s, "--x", v)` helper (a string arg, not `s["--x"]`). Teaching source-side coverage about that helper convention is a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)