### PR TITLE
fix: stop false "unused" for ampersand-family parents and modules passed to functions

### DIFF
--- a/.changeset/fix-false-positive-unused.md
+++ b/.changeset/fix-false-positive-unused.md
@@ -2,9 +2,7 @@
 'check-unused-css': patch
 ---
 
-Eliminate two sources of false "unused"/"non-existent" reports on real-world CSS-Modules codebases.
+Fix two sources of false positives.
 
-- **Ampersand-family parents are no longer falsely reported as unused.** SCSS suffix concatenation (`.--orientation { &-horizontal {} }`, also camelCase `.button { &Black {} }`, and multi-level chains) defines a parent class that source typically never references directly — only its children, often dynamically (`s[\`--orientation-${v}\`]`). A used child (directly, via a literal, or via the existing dynamic-coverage matching) now rescues every ancestor on its concatenation path. A family with no used member is still reported, and genuinely-unused siblings are still reported.
-- **A CSS module whose whole object is passed to a function is now ignored, with a clear warning.** When the imported module object is handed as a direct argument to any function call (e.g. `responsiveClassNames(s, "--nowrap", v)`, including the composed `classNames(s.root, responsiveClassNames(s, …))` form), the analyzer cannot know which classes that function applies, so it skips both the unused and the non-existent checks for that module and prints a warning naming the source file and reason. Passing a single property (`classNames(s.root, …)`) or reading the module directly (`s.foo`, `s["foo"]`, `s[\`foo-${x}\`]`) does not trigger this; only the specific module passed whole is ignored, and other modules in the same file are still analyzed. Under `--no-dynamic` the ignored module is escalated to an error, and `--remove` never touches it.
-
-Both behaviors are configless and preserve all genuine findings.
+- A parent class of an SCSS ampersand family (`.--orientation { &-horizontal {} }`) is no longer reported as unused when its children are used.
+- A CSS module passed whole into a function (e.g. `responsiveClassNames(s, …)`) is now skipped with a warning, since its class usage can't be determined.

--- a/.changeset/fix-false-positive-unused.md
+++ b/.changeset/fix-false-positive-unused.md
@@ -1,0 +1,10 @@
+---
+'check-unused-css': patch
+---
+
+Eliminate two sources of false "unused"/"non-existent" reports on real-world CSS-Modules codebases.
+
+- **Ampersand-family parents are no longer falsely reported as unused.** SCSS suffix concatenation (`.--orientation { &-horizontal {} }`, also camelCase `.button { &Black {} }`, and multi-level chains) defines a parent class that source typically never references directly — only its children, often dynamically (`s[\`--orientation-${v}\`]`). A used child (directly, via a literal, or via the existing dynamic-coverage matching) now rescues every ancestor on its concatenation path. A family with no used member is still reported, and genuinely-unused siblings are still reported.
+- **A CSS module whose whole object is passed to a function is now ignored, with a clear warning.** When the imported module object is handed as a direct argument to any function call (e.g. `responsiveClassNames(s, "--nowrap", v)`, including the composed `classNames(s.root, responsiveClassNames(s, …))` form), the analyzer cannot know which classes that function applies, so it skips both the unused and the non-existent checks for that module and prints a warning naming the source file and reason. Passing a single property (`classNames(s.root, …)`) or reading the module directly (`s.foo`, `s["foo"]`, `s[\`foo-${x}\`]`) does not trigger this; only the specific module passed whole is ignored, and other modules in the same file are still analyzed. Under `--no-dynamic` the ignored module is escalated to an error, and `--remove` never touches it.
+
+Both behaviors are configless and preserve all genuine findings.

--- a/src/__tests__/falsePositives/AmpParentCamel/AmpParentCamel.module.css
+++ b/src/__tests__/falsePositives/AmpParentCamel/AmpParentCamel.module.css
@@ -1,0 +1,11 @@
+.button {
+  display: inline-flex;
+
+  &Black {
+    background: black;
+  }
+
+  &White {
+    background: white;
+  }
+}

--- a/src/__tests__/falsePositives/AmpParentCamel/AmpParentCamel.tsx
+++ b/src/__tests__/falsePositives/AmpParentCamel/AmpParentCamel.tsx
@@ -1,0 +1,5 @@
+import s from './AmpParentCamel.module.css';
+
+// `buttonBlack` is referenced directly; `buttonWhite` is genuinely unused, and
+// the parent `button` is never written directly.
+export const AmpParentCamel = () => <div className={s.buttonBlack} />;

--- a/src/__tests__/falsePositives/AmpParentDynamicChild/AmpParentDynamicChild.module.css
+++ b/src/__tests__/falsePositives/AmpParentDynamicChild/AmpParentDynamicChild.module.css
@@ -1,0 +1,15 @@
+.--orientation {
+  display: flex;
+
+  &-horizontal {
+    flex-direction: row;
+  }
+
+  &-vertical {
+    flex-direction: column;
+  }
+}
+
+.legacy {
+  color: red;
+}

--- a/src/__tests__/falsePositives/AmpParentDynamicChild/AmpParentDynamicChild.tsx
+++ b/src/__tests__/falsePositives/AmpParentDynamicChild/AmpParentDynamicChild.tsx
@@ -1,0 +1,7 @@
+import s from './AmpParentDynamicChild.module.css';
+
+export const AmpParentDynamicChild = ({
+  orientation,
+}: {
+  orientation: 'horizontal' | 'vertical';
+}) => <div className={s[`--orientation-${orientation}`]} />;

--- a/src/__tests__/falsePositives/AmpParentLiteralChild/AmpParentLiteralChild.module.css
+++ b/src/__tests__/falsePositives/AmpParentLiteralChild/AmpParentLiteralChild.module.css
@@ -1,0 +1,11 @@
+.--variant {
+  font-weight: bold;
+
+  &-faded {
+    opacity: 0.5;
+  }
+
+  &-outline {
+    border: 1px solid;
+  }
+}

--- a/src/__tests__/falsePositives/AmpParentLiteralChild/AmpParentLiteralChild.tsx
+++ b/src/__tests__/falsePositives/AmpParentLiteralChild/AmpParentLiteralChild.tsx
@@ -1,0 +1,7 @@
+import s from './AmpParentLiteralChild.module.css';
+
+// Only the `faded` child is referenced (as a literal); `outline` is genuinely
+// unused, and the parent `--variant` is never written directly.
+export const AmpParentLiteralChild = () => (
+  <div className={s['--variant-faded']} />
+);

--- a/src/__tests__/falsePositives/ComposedHandoff/ComposedHandoff.module.css
+++ b/src/__tests__/falsePositives/ComposedHandoff/ComposedHandoff.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: inline-flex;
+}
+
+.--full-width {
+  width: 100%;
+}

--- a/src/__tests__/falsePositives/ComposedHandoff/ComposedHandoff.tsx
+++ b/src/__tests__/falsePositives/ComposedHandoff/ComposedHandoff.tsx
@@ -1,0 +1,21 @@
+import s from './ComposedHandoff.module.css';
+
+declare const classNames: (...args: unknown[]) => string;
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// The real reshaped Button shape: the whole `s` is handed to the inner
+// `responsiveClassNames` call, whose result flows into `classNames`. The object
+// still escapes into a function we cannot analyze, so the module is ignored —
+// `.--full-width` must NOT be reported as unused.
+export const ComposedHandoff = ({ fullWidth }: { fullWidth: boolean }) => (
+  <div
+    className={classNames(
+      s.root,
+      responsiveClassNames(s, '--full-width', fullWidth)
+    )}
+  />
+);

--- a/src/__tests__/falsePositives/Comprehensive/Passed.tsx
+++ b/src/__tests__/falsePositives/Comprehensive/Passed.tsx
@@ -1,0 +1,13 @@
+import s from './passed.module.css';
+
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// The whole `passed.module.css` object is handed to a function → its module is
+// ignored (no unused / non-existent reports for it), with a single warning.
+export const Passed = ({ hide }: { hide: boolean }) => (
+  <div className={responsiveClassNames(s, '--hidden', hide).join(' ')} />
+);

--- a/src/__tests__/falsePositives/Comprehensive/Widget.tsx
+++ b/src/__tests__/falsePositives/Comprehensive/Widget.tsx
@@ -1,0 +1,10 @@
+import s from './widget.module.css';
+
+// Uses one child of the `--variant` family via a literal (rescues the parent),
+// leaves `--variant-outline` and `deadCode` genuinely unused, and references a
+// `ghost` class that the stylesheet does not define (genuine non-existent).
+export const Widget = () => (
+  <div className={s['--variant-faded']}>
+    <span className={s.ghost} />
+  </div>
+);

--- a/src/__tests__/falsePositives/Comprehensive/passed.module.css
+++ b/src/__tests__/falsePositives/Comprehensive/passed.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.--hidden {
+  display: none;
+}

--- a/src/__tests__/falsePositives/Comprehensive/widget.module.css
+++ b/src/__tests__/falsePositives/Comprehensive/widget.module.css
@@ -1,0 +1,15 @@
+.--variant {
+  font-weight: bold;
+
+  &-faded {
+    opacity: 0.5;
+  }
+
+  &-outline {
+    border: 1px solid;
+  }
+}
+
+.deadCode {
+  color: red;
+}

--- a/src/__tests__/falsePositives/DirectReadOnly/DirectReadOnly.module.css
+++ b/src/__tests__/falsePositives/DirectReadOnly/DirectReadOnly.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.icon {
+  width: 1rem;
+}
+
+.orphan {
+  color: red;
+}

--- a/src/__tests__/falsePositives/DirectReadOnly/DirectReadOnly.tsx
+++ b/src/__tests__/falsePositives/DirectReadOnly/DirectReadOnly.tsx
@@ -1,0 +1,12 @@
+import s from './DirectReadOnly.module.css';
+
+// Only direct reads (member, bracket, template). The module is NOT passed to a
+// function, so it must be analyzed normally and `.orphan` must be reported.
+export const DirectReadOnly = ({ k }: { k: string }) => (
+  <div className={s.root}>
+    {/* biome-ignore lint/complexity/useLiteralKeys: the bracket-literal form is
+        deliberately exercised as a "direct read that must not trigger ignore". */}
+    <span className={s['icon']} />
+    <span className={s[`icon-${k}`]} />
+  </div>
+);

--- a/src/__tests__/falsePositives/FamilyFullyUnused/FamilyFullyUnused.module.css
+++ b/src/__tests__/falsePositives/FamilyFullyUnused/FamilyFullyUnused.module.css
@@ -1,0 +1,15 @@
+.--size {
+  font-size: 1rem;
+
+  &-small {
+    font-size: 0.75rem;
+  }
+
+  &-large {
+    font-size: 1.5rem;
+  }
+}
+
+.used {
+  color: green;
+}

--- a/src/__tests__/falsePositives/FamilyFullyUnused/FamilyFullyUnused.tsx
+++ b/src/__tests__/falsePositives/FamilyFullyUnused/FamilyFullyUnused.tsx
@@ -1,0 +1,6 @@
+import s from './FamilyFullyUnused.module.css';
+
+// No member of the `--size` family is referenced anywhere, so the parent AND
+// every child must still be reported as unused (genuine finding). Only `used`
+// keeps the module from being entirely empty of references.
+export const FamilyFullyUnused = () => <div className={s.used} />;

--- a/src/__tests__/falsePositives/GenuineNonExistent/GenuineNonExistent.module.css
+++ b/src/__tests__/falsePositives/GenuineNonExistent/GenuineNonExistent.module.css
@@ -1,0 +1,3 @@
+.root {
+  display: block;
+}

--- a/src/__tests__/falsePositives/GenuineNonExistent/GenuineNonExistent.tsx
+++ b/src/__tests__/falsePositives/GenuineNonExistent/GenuineNonExistent.tsx
@@ -1,0 +1,9 @@
+import s from './GenuineNonExistent.module.css';
+
+// `toast` does not exist in the stylesheet and the module is not passed to a
+// function, so it must still be reported as "used but non-existent".
+export const GenuineNonExistent = () => (
+  <div className={s.root}>
+    <span className={s.toast} />
+  </div>
+);

--- a/src/__tests__/falsePositives/MixedDashCamelChain/MixedDashCamelChain.module.css
+++ b/src/__tests__/falsePositives/MixedDashCamelChain/MixedDashCamelChain.module.css
@@ -1,0 +1,11 @@
+.list {
+  display: block;
+
+  &Item {
+    display: flex;
+
+    &-active {
+      font-weight: bold;
+    }
+  }
+}

--- a/src/__tests__/falsePositives/MixedDashCamelChain/MixedDashCamelChain.tsx
+++ b/src/__tests__/falsePositives/MixedDashCamelChain/MixedDashCamelChain.tsx
@@ -1,0 +1,7 @@
+import s from './MixedDashCamelChain.module.css';
+
+// Deepest leaf `listItem-active` referenced; both `list` and `listItem`
+// (a camelCase concatenation) must be rescued.
+export const MixedDashCamelChain = () => (
+  <div className={s['listItem-active']} />
+);

--- a/src/__tests__/falsePositives/MixedPassAndDirect/MixedPassAndDirect.module.css
+++ b/src/__tests__/falsePositives/MixedPassAndDirect/MixedPassAndDirect.module.css
@@ -1,0 +1,11 @@
+.root {
+  display: block;
+}
+
+.--x {
+  color: red;
+}
+
+.wouldBeUnused {
+  color: blue;
+}

--- a/src/__tests__/falsePositives/MixedPassAndDirect/MixedPassAndDirect.tsx
+++ b/src/__tests__/falsePositives/MixedPassAndDirect/MixedPassAndDirect.tsx
@@ -1,0 +1,17 @@
+import s from './MixedPassAndDirect.module.css';
+
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// Mixes a direct read (`s.root`) with a whole-object hand-off
+// (`responsiveClassNames(s, ...)`). The hand-off makes the class set
+// undeterminable, so the whole module is ignored regardless of the direct read;
+// `.wouldBeUnused` must NOT be reported.
+export const MixedPassAndDirect = ({ x }: { x: boolean }) => (
+  <div className={s.root}>
+    <span className={responsiveClassNames(s, '--x', x).join(' ')} />
+  </div>
+);

--- a/src/__tests__/falsePositives/MultiLevelLeafUsed/MultiLevelLeafUsed.module.css
+++ b/src/__tests__/falsePositives/MultiLevelLeafUsed/MultiLevelLeafUsed.module.css
@@ -1,0 +1,11 @@
+.--color {
+  color: inherit;
+
+  &-primary {
+    color: blue;
+
+    &-faded {
+      opacity: 0.5;
+    }
+  }
+}

--- a/src/__tests__/falsePositives/MultiLevelLeafUsed/MultiLevelLeafUsed.tsx
+++ b/src/__tests__/falsePositives/MultiLevelLeafUsed/MultiLevelLeafUsed.tsx
@@ -1,0 +1,7 @@
+import s from './MultiLevelLeafUsed.module.css';
+
+// Only the deepest leaf is referenced; both ancestors (`--color`,
+// `--color-primary`) must be rescued.
+export const MultiLevelLeafUsed = () => (
+  <div className={s['--color-primary-faded']} />
+);

--- a/src/__tests__/falsePositives/MultiLevelMiddleUsed/MultiLevelMiddleUsed.module.css
+++ b/src/__tests__/falsePositives/MultiLevelMiddleUsed/MultiLevelMiddleUsed.module.css
@@ -1,0 +1,11 @@
+.--color {
+  color: inherit;
+
+  &-primary {
+    color: blue;
+
+    &-faded {
+      opacity: 0.5;
+    }
+  }
+}

--- a/src/__tests__/falsePositives/MultiLevelMiddleUsed/MultiLevelMiddleUsed.tsx
+++ b/src/__tests__/falsePositives/MultiLevelMiddleUsed/MultiLevelMiddleUsed.tsx
@@ -1,0 +1,7 @@
+import s from './MultiLevelMiddleUsed.module.css';
+
+// Only the middle level is referenced; `--color` is rescued, but the deepest
+// leaf `--color-primary-faded` is genuinely unused.
+export const MultiLevelMiddleUsed = () => (
+  <div className={s['--color-primary']} />
+);

--- a/src/__tests__/falsePositives/PassedToFunctionNonExistent/PassedToFunctionNonExistent.module.css
+++ b/src/__tests__/falsePositives/PassedToFunctionNonExistent/PassedToFunctionNonExistent.module.css
@@ -1,0 +1,3 @@
+.root {
+  display: block;
+}

--- a/src/__tests__/falsePositives/PassedToFunctionNonExistent/PassedToFunctionNonExistent.tsx
+++ b/src/__tests__/falsePositives/PassedToFunctionNonExistent/PassedToFunctionNonExistent.tsx
@@ -1,0 +1,17 @@
+import s from './PassedToFunctionNonExistent.module.css';
+
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// `s` is passed whole to a function AND `s.doesNotExist` is referenced. Because
+// the module is ignored, the missing class must NOT be reported as non-existent
+// (the tool cannot determine the real class set).
+export const PassedToFunctionNonExistent = ({ on }: { on: boolean }) => (
+  <div
+    className={responsiveClassNames(s, '--x', on).join(' ')}
+    data-x={s.doesNotExist}
+  />
+);

--- a/src/__tests__/falsePositives/PassedToFunctionUnused/PassedToFunctionUnused.module.css
+++ b/src/__tests__/falsePositives/PassedToFunctionUnused/PassedToFunctionUnused.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.--nowrap {
+  flex-wrap: nowrap;
+}

--- a/src/__tests__/falsePositives/PassedToFunctionUnused/PassedToFunctionUnused.tsx
+++ b/src/__tests__/falsePositives/PassedToFunctionUnused/PassedToFunctionUnused.tsx
@@ -1,0 +1,14 @@
+import s from './PassedToFunctionUnused.module.css';
+
+// The whole module object `s` is handed to a helper that builds class keys
+// internally; the tool cannot see which classes are applied, so the module is
+// ignored — `.--nowrap` must NOT be reported as unused.
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+export const PassedToFunctionUnused = ({ nowrap }: { nowrap: boolean }) => (
+  <div className={responsiveClassNames(s, '--nowrap', nowrap).join(' ')} />
+);

--- a/src/__tests__/falsePositives/PropertyToFunction/PropertyToFunction.module.css
+++ b/src/__tests__/falsePositives/PropertyToFunction/PropertyToFunction.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.orphan {
+  color: red;
+}

--- a/src/__tests__/falsePositives/PropertyToFunction/PropertyToFunction.tsx
+++ b/src/__tests__/falsePositives/PropertyToFunction/PropertyToFunction.tsx
@@ -1,0 +1,10 @@
+import s from './PropertyToFunction.module.css';
+
+// A single property `s.root` is passed to a helper — that is a concrete,
+// observable class reference, NOT a whole-object hand-off. The module must be
+// analyzed normally, so `.orphan` must still be reported as unused.
+declare const classNames: (...args: unknown[]) => string;
+
+export const PropertyToFunction = ({ className }: { className?: string }) => (
+  <div className={classNames(s.root, className)} />
+);

--- a/src/__tests__/falsePositives/StandaloneLegacy/StandaloneLegacy.module.css
+++ b/src/__tests__/falsePositives/StandaloneLegacy/StandaloneLegacy.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.legacy {
+  color: red;
+}

--- a/src/__tests__/falsePositives/StandaloneLegacy/StandaloneLegacy.tsx
+++ b/src/__tests__/falsePositives/StandaloneLegacy/StandaloneLegacy.tsx
@@ -1,0 +1,5 @@
+import s from './StandaloneLegacy.module.css';
+
+// `legacy` is a standalone class nothing references and is not part of any
+// ampersand family, so it must still be reported as unused.
+export const StandaloneLegacy = () => <div className={s.root} />;

--- a/src/__tests__/falsePositives/TwoFilesOnePassesWhole/Handoff.tsx
+++ b/src/__tests__/falsePositives/TwoFilesOnePassesWhole/Handoff.tsx
@@ -1,0 +1,13 @@
+import s from './shared.module.css';
+
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// This importer hands the whole module to a function → the module is
+// unanalyzable and must be ignored as a whole.
+export const Handoff = ({ on }: { on: boolean }) => (
+  <div className={responsiveClassNames(s, '--passed', on).join(' ')} />
+);

--- a/src/__tests__/falsePositives/TwoFilesOnePassesWhole/Reader.tsx
+++ b/src/__tests__/falsePositives/TwoFilesOnePassesWhole/Reader.tsx
@@ -1,0 +1,6 @@
+import s from './shared.module.css';
+
+// A second importer of the SAME module references a class that does not exist
+// in the stylesheet. Because the module is ignored (the other file hands it to
+// a function), this must NOT be reported as a non-existent class.
+export const Reader = () => <div className={s.ghostMissing} />;

--- a/src/__tests__/falsePositives/TwoFilesOnePassesWhole/shared.module.css
+++ b/src/__tests__/falsePositives/TwoFilesOnePassesWhole/shared.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.--passed {
+  color: red;
+}

--- a/src/__tests__/falsePositives/TwoModulesOneIgnored/TwoModulesOneIgnored.tsx
+++ b/src/__tests__/falsePositives/TwoModulesOneIgnored/TwoModulesOneIgnored.tsx
@@ -1,0 +1,18 @@
+import s from './ignored.module.css';
+import t from './analyzed.module.css';
+
+declare const responsiveClassNames: (
+  styles: Record<string, string>,
+  name: string,
+  value: unknown
+) => string[];
+
+// `s` is passed whole → its module is ignored. `t` is only read directly → its
+// module is analyzed normally: `.tOrphan` is genuinely unused, and `t.missing`
+// references a class absent from `analyzed.module.css` (genuine non-existent).
+export const TwoModulesOneIgnored = ({ on }: { on: boolean }) => (
+  <div className={responsiveClassNames(s, '--passed', on).join(' ')}>
+    <span className={t.used} />
+    <span className={t.missing} />
+  </div>
+);

--- a/src/__tests__/falsePositives/TwoModulesOneIgnored/analyzed.module.css
+++ b/src/__tests__/falsePositives/TwoModulesOneIgnored/analyzed.module.css
@@ -1,0 +1,7 @@
+.used {
+  display: block;
+}
+
+.tOrphan {
+  color: green;
+}

--- a/src/__tests__/falsePositives/TwoModulesOneIgnored/ignored.module.css
+++ b/src/__tests__/falsePositives/TwoModulesOneIgnored/ignored.module.css
@@ -1,0 +1,7 @@
+.root {
+  display: block;
+}
+
+.--passed {
+  color: red;
+}

--- a/src/__tests__/falsePositives/falsePositives.test.ts
+++ b/src/__tests__/falsePositives/falsePositives.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from '../runCheckUnusedCss.js';
+
+const run = (folder: string) =>
+  runCheckUnusedCss(`src/__tests__/falsePositives/${folder}`);
+
+// A reported finding renders as `  <file>:<line>:<col> - .<class>\n`. To assert
+// a class is NOT reported we must anchor to the end of the token, otherwise
+// ` - .--color` would also match the line for ` - .--color-primary-faded`.
+const reportedLine = (cls: string): RegExp =>
+  new RegExp(` - \\.${cls.replace(/[-]/g, '\\$&')}(?:\\n|$)`);
+
+describe('false positives — ampersand-family parent rescue (Problem 1)', () => {
+  describe('User Story 1 — a used child rescues its parent', () => {
+    test('AmpParentDynamicChild: parent not unused (dynamic child), orphan reported', () => {
+      const result = run('AmpParentDynamicChild');
+
+      expect(result.exitCode).toBe(1);
+      // genuine: `legacy` is unused
+      expect(result.stdout).toMatch(
+        /AmpParentDynamicChild\.module\.css:\d+:\d+ - \.legacy\b/
+      );
+      // rescued: parent `--orientation` must NOT be reported
+      expect(result.stdout).not.toMatch(reportedLine('--orientation'));
+      // children are covered dynamically, never reported
+      expect(result.stdout).not.toMatch(
+        reportedLine('--orientation-horizontal')
+      );
+      expect(result.stdout).not.toMatch(reportedLine('--orientation-vertical'));
+    });
+
+    test('AmpParentLiteralChild: parent rescued by a literal child; unused sibling reported', () => {
+      const result = run('AmpParentLiteralChild');
+
+      expect(result.exitCode).toBe(1);
+      // rescued by the literal `--variant-faded`
+      expect(result.stdout).not.toMatch(reportedLine('--variant'));
+      expect(result.stdout).not.toMatch(reportedLine('--variant-faded'));
+      // genuine: `--variant-outline` is unused
+      expect(result.stdout).toMatch(
+        /AmpParentLiteralChild\.module\.css:\d+:\d+ - \.--variant-outline\b/
+      );
+    });
+
+    test('AmpParentCamel: camelCase parent rescued; unused camel sibling reported', () => {
+      const result = run('AmpParentCamel');
+
+      expect(result.exitCode).toBe(1);
+      // rescued by `s.buttonBlack`
+      expect(result.stdout).not.toMatch(reportedLine('button'));
+      expect(result.stdout).not.toMatch(reportedLine('buttonBlack'));
+      // genuine: `buttonWhite` is unused
+      expect(result.stdout).toMatch(
+        /AmpParentCamel\.module\.css:\d+:\d+ - \.buttonWhite\b/
+      );
+    });
+  });
+
+  describe('User Story 2 — multi-level families propagate "used" up the chain', () => {
+    test('MultiLevelLeafUsed: deepest leaf rescues all ancestors', () => {
+      const result = run('MultiLevelLeafUsed');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/No unused CSS classes found/);
+      expect(result.stdout).not.toMatch(reportedLine('--color'));
+      expect(result.stdout).not.toMatch(reportedLine('--color-primary'));
+    });
+
+    test('MultiLevelMiddleUsed: ancestors rescued, deeper orphan still reported', () => {
+      const result = run('MultiLevelMiddleUsed');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).not.toMatch(reportedLine('--color'));
+      expect(result.stdout).not.toMatch(reportedLine('--color-primary'));
+      // genuine: the unreferenced leaf
+      expect(result.stdout).toMatch(
+        /MultiLevelMiddleUsed\.module\.css:\d+:\d+ - \.--color-primary-faded\b/
+      );
+    });
+
+    test('MixedDashCamelChain: mixed dash/camel ancestors all rescued', () => {
+      const result = run('MixedDashCamelChain');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/No unused CSS classes found/);
+      expect(result.stdout).not.toMatch(reportedLine('list'));
+      expect(result.stdout).not.toMatch(reportedLine('listItem'));
+    });
+  });
+
+  describe('User Story 6 — genuine findings preserved', () => {
+    test('FamilyFullyUnused: an entirely-unused family still reports parent and children', () => {
+      const result = run('FamilyFullyUnused');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(
+        /FamilyFullyUnused\.module\.css:\d+:\d+ - \.--size\b/
+      );
+      expect(result.stdout).toMatch(
+        /FamilyFullyUnused\.module\.css:\d+:\d+ - \.--size-small\b/
+      );
+      expect(result.stdout).toMatch(
+        /FamilyFullyUnused\.module\.css:\d+:\d+ - \.--size-large\b/
+      );
+    });
+
+    test('StandaloneLegacy: a standalone unreferenced class is still unused', () => {
+      const result = run('StandaloneLegacy');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(
+        /StandaloneLegacy\.module\.css:\d+:\d+ - \.legacy\b/
+      );
+    });
+
+    test('GenuineNonExistent: a missing class is still reported as non-existent', () => {
+      const result = run('GenuineNonExistent');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(
+        /Found .* classes used in source files but non-existent/
+      );
+      expect(result.stdout).toMatch(
+        /GenuineNonExistent\.tsx:\d+:\d+ - \.toast\b/
+      );
+    });
+  });
+
+  describe('Comprehensive — both fixes together with genuine findings', () => {
+    test('only genuine findings remain; exactly one ignore warning', () => {
+      const result = run('Comprehensive');
+
+      expect(result.exitCode).toBe(1);
+
+      // Rescued: the `--variant` parent (a literal child is used) is not unused.
+      expect(result.stdout).not.toMatch(reportedLine('--variant'));
+      expect(result.stdout).not.toMatch(reportedLine('--variant-faded'));
+
+      // Ignored module: none of `passed.module.css`'s classes are reported.
+      expect(result.stdout).not.toMatch(reportedLine('--hidden'));
+      expect(result.stdout).not.toMatch(reportedLine('root'));
+
+      // Genuine unused: the unreferenced sibling and the dead standalone class.
+      expect(result.stdout).toMatch(
+        /widget\.module\.css:\d+:\d+ - \.--variant-outline\b/
+      );
+      expect(result.stdout).toMatch(
+        /widget\.module\.css:\d+:\d+ - \.deadCode\b/
+      );
+
+      // Genuine non-existent: `ghost` is referenced but absent from the CSS.
+      expect(result.stdout).toMatch(/Widget\.tsx:\d+:\d+ - \.ghost\b/);
+
+      // Exactly one ignore warning, naming the ignored module.
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.stdout).toMatch(/module: .*passed\.module\.css/);
+      const ignoreHeaderCount = (
+        result.stderr.match(/CSS module\(s\) ignored/g) ?? []
+      ).length;
+      expect(ignoreHeaderCount).toBe(1);
+    });
+  });
+});

--- a/src/__tests__/falsePositives/passedToFunction.test.ts
+++ b/src/__tests__/falsePositives/passedToFunction.test.ts
@@ -99,5 +99,21 @@ describe('false positives — whole CSS module passed to a function (Problem 2)'
       );
       expect(result.exitCode).toBe(1);
     });
+
+    test('TwoFilesOnePassesWhole: a hand-off in one importer ignores the module for ALL importers', () => {
+      const result = run('TwoFilesOnePassesWhole');
+
+      // Handoff.tsx passes the whole module → the module is ignored as a whole.
+      // Reader.tsx references a missing class, but because the module is
+      // ignored it must NOT be reported as non-existent (whole-module skip,
+      // matching the unused path).
+      expect(result.stdout).not.toMatch(reportedLine('ghostMissing'));
+      expect(result.stderr).not.toMatch(
+        /Found .* classes used in source files but non-existent/
+      );
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      // No genuine findings remain, so the run is clean.
+      expect(result.exitCode).toBe(0);
+    });
   });
 });

--- a/src/__tests__/falsePositives/passedToFunction.test.ts
+++ b/src/__tests__/falsePositives/passedToFunction.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from '../runCheckUnusedCss.js';
+
+const run = (folder: string) =>
+  runCheckUnusedCss(`src/__tests__/falsePositives/${folder}`);
+
+const reportedLine = (cls: string): RegExp =>
+  new RegExp(` - \\.${cls.replace(/[-]/g, '\\$&')}(?:\\n|$)`);
+
+describe('false positives — whole CSS module passed to a function (Problem 2)', () => {
+  describe('User Story 3 — whole module passed to a function is ignored, with a warning', () => {
+    test('PassedToFunctionUnused: no unused reported; ignore warning printed', () => {
+      const result = run('PassedToFunctionUnused');
+
+      // No unused finding for the ignored module.
+      expect(result.stdout).not.toMatch(reportedLine('--nowrap'));
+      expect(result.stdout).not.toMatch(reportedLine('root'));
+      // A distinct warning (header on stderr) names the reason; the per-module
+      // detail line (source file + module) is printed to stdout.
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.stdout).toMatch(/PassedToFunctionUnused\.tsx/);
+      expect(result.stdout).toMatch(
+        /module: .*PassedToFunctionUnused\.module\.css/
+      );
+      // The warning alone does not flip the exit code.
+      expect(result.exitCode).toBe(0);
+    });
+
+    test('PassedToFunctionNonExistent: missing class suppressed for the ignored module', () => {
+      const result = run('PassedToFunctionNonExistent');
+
+      expect(result.stdout).not.toMatch(reportedLine('doesNotExist'));
+      expect(result.stderr).not.toMatch(
+        /Found .* classes used in source files but non-existent/
+      );
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.exitCode).toBe(0);
+    });
+
+    test('DirectReadOnly: direct-only reads are analyzed normally (orphan reported, no warning)', () => {
+      const result = run('DirectReadOnly');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(
+        /DirectReadOnly\.module\.css:\d+:\d+ - \.orphan\b/
+      );
+      expect(result.stderr).not.toMatch(/passed to a function/i);
+    });
+
+    test('ComposedHandoff: classNames(..., responsiveClassNames(s, ...)) ignores the module', () => {
+      const result = run('ComposedHandoff');
+
+      // The whole `s` reaches the inner call, so the module is ignored and
+      // `.--full-width` is not a false unused (the real reshaped Button shape).
+      expect(result.stdout).not.toMatch(reportedLine('--full-width'));
+      expect(result.stdout).not.toMatch(reportedLine('root'));
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.stdout).toMatch(/ComposedHandoff\.tsx/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    test('PropertyToFunction: passing s.root (a property) does not ignore the module', () => {
+      const result = run('PropertyToFunction');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(
+        /PropertyToFunction\.module\.css:\d+:\d+ - \.orphan\b/
+      );
+      expect(result.stderr).not.toMatch(/passed to a function/i);
+    });
+  });
+
+  describe('User Story 4 — mixed access in one file still ignores the module', () => {
+    test('MixedPassAndDirect: hand-off dominates direct reads; module ignored + warned', () => {
+      const result = run('MixedPassAndDirect');
+
+      expect(result.stdout).not.toMatch(reportedLine('wouldBeUnused'));
+      expect(result.stdout).not.toMatch(reportedLine('--x'));
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.stdout).toMatch(/MixedPassAndDirect\.tsx/);
+    });
+  });
+
+  describe('User Story 5 — only the module passed whole is ignored', () => {
+    test('TwoModulesOneIgnored: s ignored+warned; t analyzed with genuine findings', () => {
+      const result = run('TwoModulesOneIgnored');
+
+      // s's module is ignored: its classes never appear.
+      expect(result.stdout).not.toMatch(reportedLine('--passed'));
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+      expect(result.stdout).toMatch(/module: .*ignored\.module\.css/);
+
+      // t's module is analyzed normally: genuine unused AND non-existent.
+      expect(result.stdout).toMatch(
+        /analyzed\.module\.css:\d+:\d+ - \.tOrphan\b/
+      );
+      expect(result.stdout).toMatch(
+        /TwoModulesOneIgnored\.tsx:\d+:\d+ - \.missing\b/
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/src/__tests__/falsePositives/passedToFunctionFlags.test.ts
+++ b/src/__tests__/falsePositives/passedToFunctionFlags.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runCheckUnusedCss } from '../runCheckUnusedCss.js';
+
+const FIXTURES_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const run = (folder: string, opts: Parameters<typeof runCheckUnusedCss>[0]) =>
+  runCheckUnusedCss(
+    typeof opts === 'object' && opts !== null
+      ? { ...opts, targetPath: `src/__tests__/falsePositives/${folder}` }
+      : `src/__tests__/falsePositives/${folder}`
+  );
+
+describe('whole-module-passed-to-function — flag interactions', () => {
+  describe('--no-dynamic escalates an ignored module to an error', () => {
+    test('PassedToFunctionUnused: exit 1 and an Error under --no-dynamic', () => {
+      const result = run('PassedToFunctionUnused', { noDynamic: true });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/Error:.*passed to a function/i);
+    });
+
+    test('PassedToFunctionUnused: warning (exit 0) without --no-dynamic', () => {
+      const result = run('PassedToFunctionUnused', {});
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toMatch(/Warning:.*passed to a function/i);
+    });
+  });
+
+  describe('--remove never removes from an ignored module', () => {
+    const tmpDirs: string[] = [];
+
+    afterEach(() => {
+      while (tmpDirs.length > 0) {
+        const dir = tmpDirs.pop();
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    test('PassedToFunctionUnused: nothing is removed; CSS file is untouched', () => {
+      const src = path.join(FIXTURES_DIR, 'PassedToFunctionUnused');
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'scuc-fp-remove-'));
+      tmpDirs.push(tmp);
+      // Mirror the fixture into `src/` inside the temp dir so the default
+      // target path resolves to it.
+      const targetSrc = path.join(tmp, 'src');
+      fs.cpSync(src, targetSrc, { recursive: true });
+
+      const cssPath = path.join(targetSrc, 'PassedToFunctionUnused.module.css');
+      const before = fs.readFileSync(cssPath, 'utf-8');
+
+      const result = runCheckUnusedCss({
+        cwd: tmp,
+        extraArgs: ['--remove', '--yes'],
+      });
+
+      const after = fs.readFileSync(cssPath, 'utf-8');
+      expect(after).toBe(before);
+      // No edits were applied (the module was ignored, not analyzed).
+      expect(result.stdout).toMatch(/Nothing to remove\./);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,10 @@ const reportMode = (ctx: AnalysisContext): never => {
     (result) => result.status === 'withDynamicImports'
   );
 
+  const hasIgnoredModule = results.some(
+    (result) => result.status === 'ignoredPassedToFunction'
+  );
+
   const hasNonExistentClasses = results.some(
     (result) =>
       result.status === 'nonExistentClasses' &&
@@ -144,7 +148,7 @@ const reportMode = (ctx: AnalysisContext): never => {
     hasUnusedClasses ||
     hasNotImportedModules ||
     hasNonExistentClasses ||
-    (args.noDynamic && hasDynamicUsage)
+    (args.noDynamic && (hasDynamicUsage || hasIgnoredModule))
   ) {
     process.exit(EXIT_CODES.REPORT_ISSUES);
   }

--- a/src/lib/getNonExistentClassesFromCss.ts
+++ b/src/lib/getNonExistentClassesFromCss.ts
@@ -29,9 +29,11 @@ export const getNonExistentClassesFromCss = async ({
   const cssContent = getContentOfFiles({ files: [cssFile], srcDir });
   const cssClasses = extractCssClasses(cssContent);
 
-  const nonExistentClasses: NonExistentClassUsage[] = [];
-
-  // Process each importing file separately to get precise location info
+  // If ANY importing file passes the whole module object to a function, the
+  // module is unanalyzable and is ignored as a whole — matching the unused
+  // path (which returns `ignoredPassedToFunction` for the module) and the
+  // single ignore warning. Suppress the non-existent check for every importer,
+  // not just the one that handed the module off.
   for (const importingFileData of importingFilesData) {
     const sourceContent = getContentOfFiles({
       files: [importingFileData.file],
@@ -43,9 +45,6 @@ export const getNonExistentClassesFromCss = async ({
       continue;
     }
 
-    // If the whole module object is passed to a function, the class set this
-    // file actually references cannot be determined, so skip it (the unused
-    // path emits the single ignore warning for the module).
     if (
       detectModulePassedToFunction(
         sourceContent,
@@ -53,6 +52,21 @@ export const getNonExistentClassesFromCss = async ({
         importingFileData.file
       )
     ) {
+      return null;
+    }
+  }
+
+  const nonExistentClasses: NonExistentClassUsage[] = [];
+
+  // Process each importing file separately to get precise location info
+  for (const importingFileData of importingFilesData) {
+    const sourceContent = getContentOfFiles({
+      files: [importingFileData.file],
+      srcDir,
+    });
+
+    const { isFileIgnored } = parseIgnoreComments(sourceContent);
+    if (isFileIgnored) {
       continue;
     }
 

--- a/src/lib/getNonExistentClassesFromCss.ts
+++ b/src/lib/getNonExistentClassesFromCss.ts
@@ -8,6 +8,7 @@ import { extractCssClasses } from './getUnusedClassesFromCss/utils/extractCssCla
 import { extractUsedClassesWithLocations } from './getUnusedClassesFromCss/utils/extractUsedClasses.js';
 import { findFilesImportingCssModule } from './getUnusedClassesFromCss/utils/findFilesImportingCssModule/index.js';
 import { extractDynamicClassUsages } from './getUnusedClassesFromCss/utils/findUnusedClasses/utils/extractDynamicClassUsages.js';
+import { detectModulePassedToFunction } from './getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.js';
 
 type GetNonExistentClassesFromCssParams = {
   cssFile: string;
@@ -39,6 +40,19 @@ export const getNonExistentClassesFromCss = async ({
 
     const { isFileIgnored } = parseIgnoreComments(sourceContent);
     if (isFileIgnored) {
+      continue;
+    }
+
+    // If the whole module object is passed to a function, the class set this
+    // file actually references cannot be determined, so skip it (the unused
+    // path emits the single ignore warning for the module).
+    if (
+      detectModulePassedToFunction(
+        sourceContent,
+        importingFileData.importName,
+        importingFileData.file
+      )
+    ) {
       continue;
     }
 

--- a/src/lib/getNonExistentClassesFromCss.ts
+++ b/src/lib/getNonExistentClassesFromCss.ts
@@ -29,11 +29,8 @@ export const getNonExistentClassesFromCss = async ({
   const cssContent = getContentOfFiles({ files: [cssFile], srcDir });
   const cssClasses = extractCssClasses(cssContent);
 
-  // If ANY importing file passes the whole module object to a function, the
-  // module is unanalyzable and is ignored as a whole — matching the unused
-  // path (which returns `ignoredPassedToFunction` for the module) and the
-  // single ignore warning. Suppress the non-existent check for every importer,
-  // not just the one that handed the module off.
+  // If any importer passes the whole module to a function, ignore the module
+  // entirely (matching the unused path), not just that one file.
   for (const importingFileData of importingFilesData) {
     const sourceContent = getContentOfFiles({
       files: [importingFileData.file],

--- a/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
+++ b/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
@@ -66,10 +66,8 @@ export const getUnusedClassesFromCss = async ({
       continue;
     }
 
-    // If the whole module object is passed to a function, we cannot know which
-    // classes that function applies — mark the module ignored (suppress unused
-    // AND non-existent checks) and surface a warning instead of false unused
-    // reports. A single hand-off in any importing file ignores the module.
+    // The whole module passed to a function → we can't tell which classes it
+    // uses, so ignore the module (one hand-off in any file is enough).
     const passedSite = detectModulePassedToFunction(
       sourceContent,
       importingFileData.importName,
@@ -137,10 +135,8 @@ export const getUnusedClassesFromCss = async ({
     usedClasses.add(className);
   }
 
-  // A used member of an ampersand-suffix concatenation family rescues its
-  // ancestor classes (e.g. a used `--orientation-horizontal` keeps the parent
-  // `--orientation` from being reported unused). Runs after every "used"
-  // signal — static, literal, and dynamic coverage — has been merged in.
+  // A used child keeps its ampersand-family parent from looking unused. Runs
+  // after every "used" signal (static, literal, dynamic coverage) is merged in.
   rescueUsedAncestors(usedClasses, ancestry);
 
   const unusedClasses: string[] = [];

--- a/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
+++ b/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
@@ -10,9 +10,15 @@ import {
   type ClassAccess,
   extractClassAccesses,
 } from './utils/coverage/index.js';
-import { extractCssClassesWithLocations } from './utils/extractCssClasses/index.js';
+import {
+  type ClassAncestry,
+  extractCssClassAncestry,
+  extractCssClassesWithLocations,
+} from './utils/extractCssClasses/index.js';
+import { rescueUsedAncestors } from './utils/rescueUsedAncestors.js';
 import { extractUsedClasses } from './utils/extractUsedClasses.js';
 import { findFilesImportingCssModule } from './utils/findFilesImportingCssModule/index.js';
+import { detectModulePassedToFunction } from './utils/passedToFunction/detectModulePassedToFunction.js';
 
 type GetUnusedClassesFromCssParams = {
   cssFile: string;
@@ -26,6 +32,7 @@ export const getUnusedClassesFromCss = async ({
   const cssContent = getContentOfFiles({ files: [cssFile], srcDir });
   const cssClassesWithLocations = extractCssClassesWithLocations(cssContent);
   const cssClasses = cssClassesWithLocations.map((info) => info.className);
+  const ancestry: ClassAncestry = extractCssClassAncestry(cssContent);
 
   if (cssClasses.length === 0) {
     return null;
@@ -57,6 +64,26 @@ export const getUnusedClassesFromCss = async ({
         usedClasses.add(className);
       }
       continue;
+    }
+
+    // If the whole module object is passed to a function, we cannot know which
+    // classes that function applies — mark the module ignored (suppress unused
+    // AND non-existent checks) and surface a warning instead of false unused
+    // reports. A single hand-off in any importing file ignores the module.
+    const passedSite = detectModulePassedToFunction(
+      sourceContent,
+      importingFileData.importName,
+      importingFileData.file
+    );
+    if (passedSite) {
+      return {
+        file: cssFile,
+        status: 'ignoredPassedToFunction',
+        sourceFile: importingFileData.file,
+        importName: importingFileData.importName,
+        line: passedSite.line,
+        column: passedSite.column,
+      };
     }
 
     // Static usages (importName.foo / importName['foo']) are collected via a
@@ -109,6 +136,12 @@ export const getUnusedClassesFromCss = async ({
   for (const className of coveredClasses) {
     usedClasses.add(className);
   }
+
+  // A used member of an ampersand-suffix concatenation family rescues its
+  // ancestor classes (e.g. a used `--orientation-horizontal` keeps the parent
+  // `--orientation` from being reported unused). Runs after every "used"
+  // signal — static, literal, and dynamic coverage — has been merged in.
+  rescueUsedAncestors(usedClasses, ancestry);
 
   const unusedClasses: string[] = [];
   for (const className of cssClasses) {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import { extractCssClassAncestry } from './extractCssClassAncestry.js';
+
+describe('extractCssClassAncestry', () => {
+  describe('dash-suffix concatenation', () => {
+    test('links each &-suffix child to its parent class', () => {
+      const css = `
+        .--orientation {
+          &-horizontal { color: red; }
+          &-vertical { color: blue; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.get('--orientation-horizontal')).toBe('--orientation');
+      expect(ancestry.get('--orientation-vertical')).toBe('--orientation');
+    });
+  });
+
+  describe('camelCase-suffix concatenation', () => {
+    test('links a camelCase &-suffix child to its parent class', () => {
+      const css = `
+        .button {
+          &Black { color: black; }
+          &White { color: white; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.get('buttonBlack')).toBe('button');
+      expect(ancestry.get('buttonWhite')).toBe('button');
+    });
+  });
+
+  describe('multi-level concatenation', () => {
+    test('records a single hop at each level of the chain', () => {
+      const css = `
+        .--color {
+          &-primary {
+            &-faded { opacity: 0.5; }
+          }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.get('--color-primary')).toBe('--color');
+      expect(ancestry.get('--color-primary-faded')).toBe('--color-primary');
+    });
+
+    test('records hops for a mixed dash/camel chain', () => {
+      const css = `
+        .list {
+          &Item {
+            &-active { color: green; }
+          }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.get('listItem')).toBe('list');
+      expect(ancestry.get('listItem-active')).toBe('listItem');
+    });
+  });
+
+  describe('non-concatenation rules produce no link', () => {
+    test('descendant nesting (& .child) is not a family link', () => {
+      const css = `
+        .root {
+          & .icon { color: red; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.has('icon')).toBe(false);
+    });
+
+    test('compound modifier (&.--reversed) is not a family link', () => {
+      // `&.--reversed` resolves to the standalone class `--reversed`, which is
+      // a separate class on the same element — not a suffix-concatenation of
+      // the parent — so it must not be linked to the parent.
+      const css = `
+        .root {
+          &.--reversed { color: red; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.has('--reversed')).toBe(false);
+    });
+
+    test('an unrelated top-level class sharing a name prefix is not linked', () => {
+      const css = `
+        .--orientation {
+          &-horizontal { color: red; }
+        }
+        .--orientationLegacy { color: blue; }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.has('--orientationLegacy')).toBe(false);
+      // sanity: the genuine child is still linked
+      expect(ancestry.get('--orientation-horizontal')).toBe('--orientation');
+    });
+  });
+
+  describe('composed classes are excluded', () => {
+    test('a composed child does not appear in the ancestry map', () => {
+      const css = `
+        .--variant {
+          &-faded {
+            composes: base;
+            color: red;
+          }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      // `base` is composed-from, never a real child here
+      expect(ancestry.has('base')).toBe(false);
+    });
+  });
+
+  describe('ignored files and lines', () => {
+    test('returns an empty map for a file-level ignore directive', () => {
+      const css = `
+        /* check-unused-css-disable */
+        .--orientation {
+          &-horizontal { color: red; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.size).toBe(0);
+    });
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.test.ts
@@ -94,6 +94,20 @@ describe('extractCssClassAncestry', () => {
       // sanity: the genuine child is still linked
       expect(ancestry.get('--orientation-horizontal')).toBe('--orientation');
     });
+
+    test('a prefix-sharing sibling in the SAME selector list as a suffix-& is not linked', () => {
+      // `.buttonLegacy` is a separate selector in the list, not produced by
+      // `&Black`; it must not be recorded as a child even though it shares the
+      // `button` prefix (otherwise using it would wrongly rescue `.button`).
+      const css = `
+        .button {
+          &Black, .buttonLegacy { color: black; }
+        }
+      `;
+      const ancestry = extractCssClassAncestry(css);
+      expect(ancestry.get('buttonBlack')).toBe('button');
+      expect(ancestry.has('buttonLegacy')).toBe(false);
+    });
   });
 
   describe('composed classes are excluded', () => {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
@@ -1,9 +1,10 @@
 import postcssScss from 'postcss-scss';
 import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
-import { extractClassNamesFromRule } from './utils/extractClassNamesFromRule.js';
+import { extractClassNamesFromSelector } from './utils/extractClassNamesFromRule.js';
 import { extractComposedClasses } from './utils/extractComposedClasses.js';
 import {
   getParentClassName,
+  resolveAmpersandSelector,
   SUFFIX_AMPERSAND_REGEX,
 } from './utils/resolveAmpersandSelector.js';
 
@@ -51,15 +52,27 @@ export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
       return;
     }
 
-    for (const className of extractClassNamesFromRule(rule)) {
-      // A genuine suffix concatenation is the parent name plus a non-empty
-      // suffix. This excludes the parent itself and any class that does not
-      // structurally extend the parent (e.g. a `&.--reversed` modifier).
-      if (
-        className !== parentClassName &&
-        className.startsWith(parentClassName)
-      ) {
-        ancestry.set(className, parentClassName);
+    // Process each comma-separated selector independently so a sibling in the
+    // same selector list is not mistaken for a concatenation child. In
+    // `.button { &Black, .buttonLegacy { … } }` only the `&Black` segment is a
+    // suffix concatenation of the parent; `.buttonLegacy` must not be linked
+    // even though it shares the `button` prefix.
+    for (const segment of rule.selector.split(',')) {
+      if (!SUFFIX_AMPERSAND_REGEX.test(segment)) {
+        continue;
+      }
+
+      const resolved = resolveAmpersandSelector(segment, parentClassName);
+      for (const className of extractClassNamesFromSelector(resolved)) {
+        // The concatenation child is the parent name plus a non-empty suffix
+        // (excludes the parent itself and `&.--modifier` compounds, which
+        // resolve to a standalone class that does not extend the parent).
+        if (
+          className !== parentClassName &&
+          className.startsWith(parentClassName)
+        ) {
+          ancestry.set(className, parentClassName);
+        }
       }
     }
   });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
@@ -1,0 +1,75 @@
+import postcssScss from 'postcss-scss';
+import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
+import { extractClassNamesFromRule } from './utils/extractClassNamesFromRule.js';
+import { extractComposedClasses } from './utils/extractComposedClasses.js';
+import {
+  getParentClassName,
+  SUFFIX_AMPERSAND_REGEX,
+} from './utils/resolveAmpersandSelector.js';
+
+/**
+ * A child class name → its immediate parent class name, recorded only for SCSS
+ * ampersand *suffix* concatenation (`.--orientation { &-horizontal {} }` →
+ * `--orientation-horizontal → --orientation`; `.button { &Black {} }` →
+ * `buttonBlack → button`). Multi-level nesting yields one hop per level; the
+ * full chain is recovered by walking the map transitively.
+ *
+ * Intentionally NOT recorded:
+ *  - descendant nesting (`& .child`) — `child` is unrelated to the parent,
+ *  - compound modifiers (`&.--reversed`) — resolves to the standalone class
+ *    `--reversed`, a separate class on the same element, not a concatenation,
+ *  - any class whose resolved name is not the parent name plus a suffix — this
+ *    keeps the relationship derived from the real concatenation rather than
+ *    loose name-prefix matching.
+ */
+export type ClassAncestry = Map<string, string>;
+
+export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
+  const { isFileIgnored, ignoredLines } = parseIgnoreComments(cssContent);
+
+  const ancestry: ClassAncestry = new Map();
+
+  if (isFileIgnored) {
+    return ancestry;
+  }
+
+  const root = postcssScss.parse(cssContent);
+
+  root.walkRules((rule) => {
+    if (rule.source?.start && ignoredLines.has(rule.source.start.line)) {
+      return;
+    }
+
+    // Only suffix-`&` rules (`&-x`, `&Camel`) can produce a concatenation
+    // child. `&.x`, `& .x`, `&:hover`, and selectors without `&` cannot.
+    if (!SUFFIX_AMPERSAND_REGEX.test(rule.selector)) {
+      return;
+    }
+
+    const parentClassName = getParentClassName(rule);
+    if (!parentClassName) {
+      return;
+    }
+
+    for (const className of extractClassNamesFromRule(rule)) {
+      // A genuine suffix concatenation is the parent name plus a non-empty
+      // suffix. This excludes the parent itself and any class that does not
+      // structurally extend the parent (e.g. a `&.--reversed` modifier).
+      if (
+        className !== parentClassName &&
+        className.startsWith(parentClassName)
+      ) {
+        ancestry.set(className, parentClassName);
+      }
+    }
+  });
+
+  // A class removed because it is `composes:`-d from elsewhere is not a real
+  // family member here, so it must not be able to rescue a parent.
+  const composedClasses = extractComposedClasses(root);
+  for (const composedClassName of composedClasses) {
+    ancestry.delete(composedClassName);
+  }
+
+  return ancestry;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
@@ -9,19 +9,13 @@ import {
 } from './utils/resolveAmpersandSelector.js';
 
 /**
- * A child class name → its immediate parent class name, recorded only for SCSS
- * ampersand *suffix* concatenation (`.--orientation { &-horizontal {} }` →
- * `--orientation-horizontal → --orientation`; `.button { &Black {} }` →
- * `buttonBlack → button`). Multi-level nesting yields one hop per level; the
- * full chain is recovered by walking the map transitively.
+ * Maps a child class to its immediate parent, for SCSS suffix concatenation
+ * only: `.--orientation { &-horizontal {} }` → `--orientation-horizontal →
+ * --orientation`, `.button { &Black {} }` → `buttonBlack → button`. Multi-level
+ * nesting stores one hop per level; walk the map to get the full chain.
  *
- * Intentionally NOT recorded:
- *  - descendant nesting (`& .child`) — `child` is unrelated to the parent,
- *  - compound modifiers (`&.--reversed`) — resolves to the standalone class
- *    `--reversed`, a separate class on the same element, not a concatenation,
- *  - any class whose resolved name is not the parent name plus a suffix — this
- *    keeps the relationship derived from the real concatenation rather than
- *    loose name-prefix matching.
+ * Descendant nesting (`& .child`) and compound modifiers (`&.--reversed`) are
+ * not concatenation, so they are not recorded.
  */
 export type ClassAncestry = Map<string, string>;
 
@@ -52,11 +46,9 @@ export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
       return;
     }
 
-    // Process each comma-separated selector independently so a sibling in the
-    // same selector list is not mistaken for a concatenation child. In
-    // `.button { &Black, .buttonLegacy { … } }` only the `&Black` segment is a
-    // suffix concatenation of the parent; `.buttonLegacy` must not be linked
-    // even though it shares the `button` prefix.
+    // Handle each selector in the list separately, so a sibling like
+    // `.buttonLegacy` in `.button { &Black, .buttonLegacy {} }` isn't taken for
+    // a child just because it shares the `button` prefix.
     for (const segment of rule.selector.split(',')) {
       if (!SUFFIX_AMPERSAND_REGEX.test(segment)) {
         continue;
@@ -64,9 +56,8 @@ export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
 
       const resolved = resolveAmpersandSelector(segment, parentClassName);
       for (const className of extractClassNamesFromSelector(resolved)) {
-        // The concatenation child is the parent name plus a non-empty suffix
-        // (excludes the parent itself and `&.--modifier` compounds, which
-        // resolve to a standalone class that does not extend the parent).
+        // A real child is the parent name plus a suffix (excludes the parent
+        // itself and `&.--modifier` compounds that don't extend it).
         if (
           className !== parentClassName &&
           className.startsWith(parentClassName)

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/index.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/index.ts
@@ -1,4 +1,8 @@
 export {
+  type ClassAncestry,
+  extractCssClassAncestry,
+} from './extractCssClassAncestry.js';
+export {
   type CssClassInfo,
   extractCssClasses,
   extractCssClassesWithLocations,

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -23,7 +23,7 @@ const parseSelector: Parser = createParser({ strict: false });
  * into the class names it defines. Returns an empty array if the selector
  * cannot be parsed at all.
  */
-const extractClassNamesFromSelector = (selector: string): string[] => {
+export const extractClassNamesFromSelector = (selector: string): string[] => {
   try {
     const processedSelector = clearGlobalSelectors(selector);
     const parsed = parseSelector(processedSelector);

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
@@ -85,11 +85,10 @@ export const getParentClassName = (rule: Rule): string | null => {
 };
 
 /**
- * Matches a *suffix* ampersand: an `&` immediately followed by an identifier
- * character, i.e. SCSS suffix concatenation (`&-horizontal`, `&Black`,
- * `&__element`). It deliberately does NOT match `&.x` (compound), `& .x`
- * (descendant), or `&:hover` (pseudo). Non-global so `.test()` is stateless;
- * the `g` flag is added locally where a replace-all is needed.
+ * A suffix `&`: an `&` directly followed by an identifier char — SCSS
+ * concatenation like `&-horizontal`, `&Black`, `&__element`. Does not match
+ * `&.x`, `& .x`, or `&:hover`. Non-global so `.test()` is stateless; callers
+ * add the `g` flag when replacing.
  */
 export const SUFFIX_AMPERSAND_REGEX = /&(?=[A-Za-z0-9_-])/;
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
@@ -84,6 +84,15 @@ export const getParentClassName = (rule: Rule): string | null => {
   return getLastClassName(parentRule.selector);
 };
 
+/**
+ * Matches a *suffix* ampersand: an `&` immediately followed by an identifier
+ * character, i.e. SCSS suffix concatenation (`&-horizontal`, `&Black`,
+ * `&__element`). It deliberately does NOT match `&.x` (compound), `& .x`
+ * (descendant), or `&:hover` (pseudo). Non-global so `.test()` is stateless;
+ * the `g` flag is added locally where a replace-all is needed.
+ */
+export const SUFFIX_AMPERSAND_REGEX = /&(?=[A-Za-z0-9_-])/;
+
 export const resolveAmpersandSelector = (
   selector: string,
   parentClassName: string | null
@@ -92,5 +101,8 @@ export const resolveAmpersandSelector = (
     return selector;
   }
 
-  return selector.replace(/&(?=[A-Za-z0-9_-])/g, `.${parentClassName}`);
+  return selector.replace(
+    new RegExp(SUFFIX_AMPERSAND_REGEX, 'g'),
+    `.${parentClassName}`
+  );
 };

--- a/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test';
+import { detectModulePassedToFunction } from './detectModulePassedToFunction.js';
+
+const detect = (source: string, importName = 's') =>
+  detectModulePassedToFunction(source, importName);
+
+describe('detectModulePassedToFunction', () => {
+  describe('triggers when the whole module object is a direct call argument', () => {
+    test('fn(s, x) triggers and returns a location', () => {
+      const result = detect(`import s from './x.module.css';\nfn(s, 1);`);
+      expect(result).not.toBeNull();
+      expect(result?.line).toBe(2);
+      expect(typeof result?.column).toBe('number');
+    });
+
+    test('responsiveClassNames(s, "--x", v) triggers', () => {
+      const result = detect(
+        `import s from './x.module.css';\nconst c = responsiveClassNames(s, "--x", v);`
+      );
+      expect(result).not.toBeNull();
+    });
+
+    test('triggers even when s is a later argument', () => {
+      const result = detect(`import s from './x.module.css';\ncx(prefix, s);`);
+      expect(result).not.toBeNull();
+    });
+
+    test('triggers for the composed form classNames(..., responsiveClassNames(s, ...))', () => {
+      // The whole `s` reaches the inner `responsiveClassNames` call, even though
+      // that call's result then flows into `classNames`. The object still
+      // escapes into a function we cannot analyze.
+      const result = detect(
+        `classNames(s.root, responsiveClassNames(s, "--x", v));`
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('does NOT trigger for property hand-off or direct reads', () => {
+    test('fn(s.root, x) does not trigger (property, not whole object)', () => {
+      expect(detect(`fn(s.root, 1);`)).toBeNull();
+    });
+
+    test('classNames(s.root, ...) with a dynamic property read does not trigger', () => {
+      // The `${x}` here is part of the JS source under test, not a placeholder
+      // for this file; written as a template literal with an escaped `\${`.
+      expect(
+        detect(`classNames(s.root, cond && s[\`--c-\${x}\`]);`)
+      ).toBeNull();
+    });
+
+    test('member read s.foo does not trigger', () => {
+      expect(detect(`const a = s.foo;`)).toBeNull();
+    });
+
+    test('bracket read s["foo"] does not trigger', () => {
+      expect(detect(`const a = s["foo"];`)).toBeNull();
+    });
+
+    test('template-literal property read does not trigger', () => {
+      expect(detect(`const a = s[\`foo-\${x}\`];`)).toBeNull();
+    });
+  });
+
+  describe('triggers when s is a direct argument of an inner call', () => {
+    test('fn(wrap(s)) triggers (s is a direct argument of wrap)', () => {
+      // `s` is handed whole to `wrap`; we cannot see what `wrap` does with it,
+      // so ignoring the module is the conservative, zero-false-positive choice.
+      expect(detect(`fn(wrap(s));`)).not.toBeNull();
+    });
+  });
+
+  describe('does NOT trigger for non-call positions (documented boundary)', () => {
+    test('fn([s]) does not trigger (s is inside an array literal)', () => {
+      expect(detect(`fn([s]);`)).toBeNull();
+    });
+
+    test('fn({ styles: s }) does not trigger (s is a property value)', () => {
+      expect(detect(`fn({ styles: s });`)).toBeNull();
+    });
+
+    test('spread {...s} does not trigger', () => {
+      expect(detect(`const x = { ...s };`)).toBeNull();
+    });
+
+    test('assignment const x = s does not trigger', () => {
+      expect(detect(`const x = s;`)).toBeNull();
+    });
+
+    test('return s does not trigger', () => {
+      expect(detect(`function f() { return s; }`)).toBeNull();
+    });
+
+    test('JSX prop prop={s} does not trigger', () => {
+      expect(detect(`const e = <Comp prop={s} />;`)).toBeNull();
+    });
+
+    test('new Wrapper(s) does not trigger (NewExpression, not CallExpression)', () => {
+      expect(detect(`const w = new Wrapper(s);`)).toBeNull();
+    });
+  });
+
+  describe('per-module scoping', () => {
+    test('matches only the requested import name', () => {
+      const source = `fn(s, 1);\notherFn(t.foo);`;
+      expect(detectModulePassedToFunction(source, 't')).toBeNull();
+      expect(detectModulePassedToFunction(source, 's')).not.toBeNull();
+    });
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
@@ -9,43 +9,22 @@ export type PassedToFunctionSite = {
 };
 
 /**
- * Detect whether the whole imported CSS-module object (`importName`, e.g. `s`)
- * is passed as a *direct argument* to any function call in the source — the
- * case `responsiveClassNames(s, "--x", v)`, where a helper builds class keys
- * internally and the analyzer cannot see which classes are applied.
+ * Find where the imported module object (`importName`) is passed straight into
+ * a function call, e.g. `responsiveClassNames(s, "--x", v)`. The helper builds
+ * class names internally, so we can't tell which classes it uses — the caller
+ * uses this to ignore the module instead of reporting false positives.
  *
- * Returns the location of the first such call site, or `null` if none.
+ * Triggers when `importName` is a bare argument of any call, including the
+ * nested `classNames(s.root, responsiveClassNames(s, …))` form. Does NOT
+ * trigger on `s.root` (a property, not the whole object), plain reads
+ * (`s.foo`), or `s` wrapped in something else (`fn([s])`, `{ ...s }`, `new
+ * Wrapper(s)`).
  *
- * The trigger fires whenever a bare `Identifier` matching `importName` is a
- * direct element of *some* `CallExpression`'s `arguments`. That includes the
- * common composed form `classNames(s.root, responsiveClassNames(s, …))`, where
- * the whole object reaches the inner `responsiveClassNames` call — the object
- * still escapes into a function we cannot analyze, so the conservative,
- * zero-false-positive choice is to ignore the module.
+ * Like the other AST passes here, it matches by name without scope resolution.
+ * A shadowing local named `s` could trigger too, but that only ignores a module
+ * (never a false finding) and doesn't happen with real module bindings.
  *
- * Deliberately NOT triggered by:
- *  - `fn(s.root, …)` — the argument is a `MemberExpression`, not the bare
- *    object; a property is already a concrete, observable class reference;
- *  - direct reads `s.foo` / `s["foo"]` / `` s[`foo-${x}`] `` — not call args;
- *  - `fn([s])`, `fn({ styles: s })` — `s` is wrapped in an array/object
- *    literal, not a direct call argument (out of scope; the object is not
- *    handed to the function as-is);
- *  - non-call uses: spread `{...s}`, `const x = s`, `return s`, JSX `prop={s}`;
- *  - `new Wrapper(s)` — a `NewExpression`, not a `CallExpression`.
- *
- * A source the parser cannot handle throws (via `contentToAst`), surfacing as
- * an INTERNAL error naming the offending file — the project's policy for
- * unparseable input.
- *
- * Like the other source-AST passes in this codebase (`extractUsedClasses`,
- * `extractClassAccesses`), this matches the import binding by name and does not
- * perform full scope resolution. A local variable or parameter that shadows the
- * import name and is itself passed to a function would therefore also trigger.
- * That is intentionally conservative: a spurious match only ever *ignores* a
- * module (suppressing reports), never produces a false unused/non-existent
- * finding — consistent with this feature's zero-false-positive priority. CSS
- * module bindings (`s`, `styles`) are module-scoped and not shadowed in
- * practice, so this has no observed effect on real codebases.
+ * Returns the first call site, or `null`. Throws on unparseable input.
  */
 export const detectModulePassedToFunction = (
   sourceContent: string,

--- a/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
@@ -36,6 +36,16 @@ export type PassedToFunctionSite = {
  * A source the parser cannot handle throws (via `contentToAst`), surfacing as
  * an INTERNAL error naming the offending file — the project's policy for
  * unparseable input.
+ *
+ * Like the other source-AST passes in this codebase (`extractUsedClasses`,
+ * `extractClassAccesses`), this matches the import binding by name and does not
+ * perform full scope resolution. A local variable or parameter that shadows the
+ * import name and is itself passed to a function would therefore also trigger.
+ * That is intentionally conservative: a spurious match only ever *ignores* a
+ * module (suppressing reports), never produces a false unused/non-existent
+ * finding — consistent with this feature's zero-false-positive priority. CSS
+ * module bindings (`s`, `styles`) are module-scoped and not shadowed in
+ * practice, so this has no observed effect on real codebases.
  */
 export const detectModulePassedToFunction = (
   sourceContent: string,

--- a/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.ts
@@ -1,0 +1,75 @@
+import type { TSESTree } from '@typescript-eslint/typescript-estree';
+import type { Node } from 'estree';
+import { walk } from 'estree-walker';
+import { contentToAst } from '../findUnusedClasses/utils/contentToAst.js';
+
+export type PassedToFunctionSite = {
+  line: number;
+  column: number;
+};
+
+/**
+ * Detect whether the whole imported CSS-module object (`importName`, e.g. `s`)
+ * is passed as a *direct argument* to any function call in the source — the
+ * case `responsiveClassNames(s, "--x", v)`, where a helper builds class keys
+ * internally and the analyzer cannot see which classes are applied.
+ *
+ * Returns the location of the first such call site, or `null` if none.
+ *
+ * The trigger fires whenever a bare `Identifier` matching `importName` is a
+ * direct element of *some* `CallExpression`'s `arguments`. That includes the
+ * common composed form `classNames(s.root, responsiveClassNames(s, …))`, where
+ * the whole object reaches the inner `responsiveClassNames` call — the object
+ * still escapes into a function we cannot analyze, so the conservative,
+ * zero-false-positive choice is to ignore the module.
+ *
+ * Deliberately NOT triggered by:
+ *  - `fn(s.root, …)` — the argument is a `MemberExpression`, not the bare
+ *    object; a property is already a concrete, observable class reference;
+ *  - direct reads `s.foo` / `s["foo"]` / `` s[`foo-${x}`] `` — not call args;
+ *  - `fn([s])`, `fn({ styles: s })` — `s` is wrapped in an array/object
+ *    literal, not a direct call argument (out of scope; the object is not
+ *    handed to the function as-is);
+ *  - non-call uses: spread `{...s}`, `const x = s`, `return s`, JSX `prop={s}`;
+ *  - `new Wrapper(s)` — a `NewExpression`, not a `CallExpression`.
+ *
+ * A source the parser cannot handle throws (via `contentToAst`), surfacing as
+ * an INTERNAL error naming the offending file — the project's policy for
+ * unparseable input.
+ */
+export const detectModulePassedToFunction = (
+  sourceContent: string,
+  importName: string,
+  filePath?: string
+): PassedToFunctionSite | null => {
+  const ast = contentToAst(sourceContent, filePath);
+
+  let site: PassedToFunctionSite | null = null;
+
+  walk(ast as Node, {
+    enter(node: Node): void {
+      if (site) {
+        return;
+      }
+
+      const call = node as unknown as TSESTree.Node;
+      if (call.type !== 'CallExpression') {
+        return;
+      }
+
+      for (const arg of call.arguments) {
+        if (arg.type === 'Identifier' && arg.name === importName) {
+          const loc = arg.loc;
+          site = {
+            line: loc ? loc.start.line : -1,
+            // AST columns are 0-based; editors show 1-based.
+            column: loc ? loc.start.column + 1 : -1,
+          };
+          return;
+        }
+      }
+    },
+  });
+
+  return site;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import type { ClassAncestry } from './extractCssClasses/index.js';
+import { rescueUsedAncestors } from './rescueUsedAncestors.js';
+
+const ancestry = (entries: Array<[string, string]>): ClassAncestry =>
+  new Map(entries);
+
+describe('rescueUsedAncestors', () => {
+  test('single hop: a used child rescues its immediate parent', () => {
+    const used = new Set(['--orientation-horizontal']);
+    rescueUsedAncestors(
+      used,
+      ancestry([
+        ['--orientation-horizontal', '--orientation'],
+        ['--orientation-vertical', '--orientation'],
+      ])
+    );
+    expect(used.has('--orientation')).toBe(true);
+    // The unused sibling is NOT pulled in.
+    expect(used.has('--orientation-vertical')).toBe(false);
+  });
+
+  test('multi hop: a deep leaf rescues every ancestor to the family root', () => {
+    const used = new Set(['--color-primary-faded']);
+    rescueUsedAncestors(
+      used,
+      ancestry([
+        ['--color-primary', '--color'],
+        ['--color-primary-faded', '--color-primary'],
+      ])
+    );
+    expect(used.has('--color-primary')).toBe(true);
+    expect(used.has('--color')).toBe(true);
+  });
+
+  test('mid-level use rescues ancestors but not deeper orphans', () => {
+    const used = new Set(['--color-primary']);
+    rescueUsedAncestors(
+      used,
+      ancestry([
+        ['--color-primary', '--color'],
+        ['--color-primary-faded', '--color-primary'],
+      ])
+    );
+    expect(used.has('--color')).toBe(true);
+    // The deeper leaf has no used descendant, so it stays unused.
+    expect(used.has('--color-primary-faded')).toBe(false);
+  });
+
+  test('a fully unused branch is never rescued', () => {
+    const used = new Set(['unrelated']);
+    rescueUsedAncestors(
+      used,
+      ancestry([
+        ['--size-small', '--size'],
+        ['--size-large', '--size'],
+      ])
+    );
+    expect(used.has('--size')).toBe(false);
+    expect(used.has('--size-small')).toBe(false);
+    expect(used.has('--size-large')).toBe(false);
+  });
+
+  test('a child whose parent is already used leaves the set unchanged', () => {
+    const used = new Set(['--orientation', '--orientation-horizontal']);
+    const before = new Set(used);
+    rescueUsedAncestors(
+      used,
+      ancestry([['--orientation-horizontal', '--orientation']])
+    );
+    expect(used).toEqual(before);
+  });
+
+  test('shared-ancestor fan-in: each ancestor is added once and the walk terminates', () => {
+    // Two used children share the same parent chain. The revisit guard must
+    // stop the second child's climb as soon as it reaches an already-collected
+    // ancestor, so the result is still correct and the walk terminates.
+    const used = new Set(['--c-a-x', '--c-b-x']);
+    rescueUsedAncestors(
+      used,
+      ancestry([
+        ['--c-a', '--c'],
+        ['--c-b', '--c'],
+        ['--c-a-x', '--c-a'],
+        ['--c-b-x', '--c-b'],
+      ])
+    );
+    expect(used.has('--c')).toBe(true);
+    expect(used.has('--c-a')).toBe(true);
+    expect(used.has('--c-b')).toBe(true);
+  });
+
+  test('empty ancestry leaves the used set unchanged', () => {
+    const used = new Set(['a', 'b']);
+    rescueUsedAncestors(used, ancestry([]));
+    expect(used).toEqual(new Set(['a', 'b']));
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.ts
@@ -1,19 +1,12 @@
 import type { ClassAncestry } from './extractCssClasses/index.js';
 
 /**
- * Given the set of classes already considered used and the ampersand-family
- * ancestry map, add every ancestor of a used class to the used set.
+ * Mark the ancestors of every used class as used too.
  *
- * Rationale: SCSS suffix concatenation (`.--orientation { &-horizontal {} }`)
- * defines a parent class (`--orientation`) that carries the shared declarations
- * its children inherit, but source code typically references only the concrete
- * children (`s[`--orientation-${v}`]`). Without this, the structurally-required
- * parent is falsely reported as unused. A used child therefore rescues every
- * ancestor on its concatenation path up to the family root.
- *
- * The walk is append-only (a class is never removed from `usedClasses`) and is
- * guarded against revisiting a class, so it terminates even though SCSS cannot
- * actually produce a cycle.
+ * SCSS suffix concatenation (`.--orientation { &-horizontal {} }`) defines a
+ * parent class that source rarely names directly — it usually references only
+ * the children. So a used child rescues its whole ancestor chain, otherwise the
+ * parent looks unused. Append-only and revisit-guarded, so it always finishes.
  */
 export const rescueUsedAncestors = (
   usedClasses: Set<string>,

--- a/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/rescueUsedAncestors.ts
@@ -1,0 +1,39 @@
+import type { ClassAncestry } from './extractCssClasses/index.js';
+
+/**
+ * Given the set of classes already considered used and the ampersand-family
+ * ancestry map, add every ancestor of a used class to the used set.
+ *
+ * Rationale: SCSS suffix concatenation (`.--orientation { &-horizontal {} }`)
+ * defines a parent class (`--orientation`) that carries the shared declarations
+ * its children inherit, but source code typically references only the concrete
+ * children (`s[`--orientation-${v}`]`). Without this, the structurally-required
+ * parent is falsely reported as unused. A used child therefore rescues every
+ * ancestor on its concatenation path up to the family root.
+ *
+ * The walk is append-only (a class is never removed from `usedClasses`) and is
+ * guarded against revisiting a class, so it terminates even though SCSS cannot
+ * actually produce a cycle.
+ */
+export const rescueUsedAncestors = (
+  usedClasses: Set<string>,
+  ancestry: ClassAncestry
+): void => {
+  const ancestorsToRescue = new Set<string>();
+
+  for (const className of usedClasses) {
+    let parent = ancestry.get(className);
+    while (
+      parent !== undefined &&
+      !usedClasses.has(parent) &&
+      !ancestorsToRescue.has(parent)
+    ) {
+      ancestorsToRescue.add(parent);
+      parent = ancestry.get(parent);
+    }
+  }
+
+  for (const ancestor of ancestorsToRescue) {
+    usedClasses.add(ancestor);
+  }
+};

--- a/src/lib/printResults.test.ts
+++ b/src/lib/printResults.test.ts
@@ -162,6 +162,49 @@ describe('printResults', () => {
     });
   });
 
+  describe('when a module is ignored because it was passed to a function', () => {
+    test('prints a distinct yellow warning naming the source file and reason', () => {
+      const results: CssAnalysisResult[] = [
+        {
+          file: 'components/View/View.module.css',
+          status: 'ignoredPassedToFunction',
+          sourceFile: 'components/View/View.tsx',
+          importName: 's',
+          line: 42,
+          column: 10,
+        },
+      ];
+
+      printResults(results);
+
+      // Distinct yellow warning header (not the dynamic-usage one).
+      const warnCalls = consoleWarnSpy.mock.calls.map((args) =>
+        String(args[0] ?? '')
+      );
+      expect(
+        warnCalls.some(
+          (s) =>
+            s.includes(COLORS.yellow) &&
+            /passed to a function/i.test(s) &&
+            !/Dynamic class usage detected/.test(s)
+        )
+      ).toBe(true);
+
+      // Names the source file and the module somewhere in the output.
+      const allOutput = [
+        ...consoleWarnSpy.mock.calls,
+        ...consoleLogSpy.mock.calls,
+      ]
+        .map((args) => String(args[0] ?? ''))
+        .join('\n');
+      expect(allOutput).toContain('View.tsx');
+      expect(allOutput).toContain('View.module.css');
+
+      // Not surfaced as a red error (it is a warning).
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when unimported files found', () => {
     test('prints information about unimported files', () => {
       const results: CssAnalysisResult[] = [

--- a/src/lib/printResults.ts
+++ b/src/lib/printResults.ts
@@ -2,6 +2,7 @@ import { COLORS } from '../consts.js';
 import type {
   CssAnalysisResult,
   DynamicClassResult,
+  ModuleIgnoredResult,
   NonExistentClassResult,
   UnusedClassResultNoClasses,
   UnusedClassResultWithClasses,
@@ -30,6 +31,11 @@ export const printResults = (
   const nonExistentClassResults = results.filter(
     (result): result is NonExistentClassResult =>
       result.status === 'nonExistentClasses'
+  );
+
+  const ignoredModuleResults = results.filter(
+    (result): result is ModuleIgnoredResult =>
+      result.status === 'ignoredPassedToFunction'
   );
 
   if (resultsWithDynamicUsage.length > 0) {
@@ -80,6 +86,33 @@ export const printResults = (
 
         console.log('');
       }
+    }
+  }
+
+  if (ignoredModuleResults.length > 0) {
+    // A module whose whole object is handed to a function cannot be analyzed:
+    // we cannot tell which classes that function applies. Surface a distinct
+    // warning (separate from the dynamic-usage one) naming the source file and
+    // the reason, rather than emitting false unused / non-existent reports.
+    // Under --no-dynamic this undeterminable case is escalated to an error.
+    const color = noDynamic ? COLORS.red : COLORS.yellow;
+    const label = noDynamic ? 'Error' : 'Warning';
+    const emit = noDynamic ? console.error : console.warn;
+
+    emit(
+      `${color}${label}: ${ignoredModuleResults.length} CSS module(s) ignored — the whole module object is passed to a function.${COLORS.reset}`
+    );
+    emit(
+      `${color}Cannot determine class usage when the module object is consumed by a function.${COLORS.reset}\n`
+    );
+
+    for (const result of ignoredModuleResults) {
+      console.log(
+        `  ${COLORS.cyan}${result.sourceFile}:${result.line}:${result.column}${COLORS.reset} - ` +
+          `${color}\`${result.importName}\` (whole module) passed to a function${COLORS.reset}`
+      );
+      console.log(`  ${COLORS.cyan}module: ${result.file}${COLORS.reset}`);
+      console.log('');
     }
   }
 

--- a/src/lib/printResults.ts
+++ b/src/lib/printResults.ts
@@ -90,11 +90,8 @@ export const printResults = (
   }
 
   if (ignoredModuleResults.length > 0) {
-    // A module whose whole object is handed to a function cannot be analyzed:
-    // we cannot tell which classes that function applies. Surface a distinct
-    // warning (separate from the dynamic-usage one) naming the source file and
-    // the reason, rather than emitting false unused / non-existent reports.
-    // Under --no-dynamic this undeterminable case is escalated to an error.
+    // Modules handed whole to a function can't be analyzed; warn (naming the
+    // file) instead of reporting false positives. --no-dynamic makes it an error.
     const color = noDynamic ? COLORS.red : COLORS.yellow;
     const label = noDynamic ? 'Error' : 'Warning';
     const emit = noDynamic ? console.error : console.warn;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,17 @@ export type DynamicClassResult = {
   status: 'withDynamicImports';
 };
 
+export type ModuleIgnoredResult = {
+  file: string;
+  status: 'ignoredPassedToFunction';
+  /** The importing source file that passed the whole module to a function. */
+  sourceFile: string;
+  /** The import binding that was passed (e.g. `s`). */
+  importName: string;
+  line: number;
+  column: number;
+};
+
 export type NonExistentClassUsage = {
   className: string;
   file: string;
@@ -44,7 +55,8 @@ export type NonExistentClassResult = {
 export type UnusedClassResult =
   | UnusedClassResultWithClasses
   | UnusedClassResultNoClasses
-  | DynamicClassResult;
+  | DynamicClassResult
+  | ModuleIgnoredResult;
 
 export type CssAnalysisResult = UnusedClassResult | NonExistentClassResult;
 


### PR DESCRIPTION
## What

Eliminates two recurring false-positive sources confirmed by running the tool against the real **reshaped** design system.

### Problem 1 — ampersand-family parent reported unused
SCSS suffix concatenation defines a parent class that source rarely references directly — only its children, often dynamically:

```css
.--orientation { &-horizontal {} &-vertical {} }   /* parent --orientation never written in code */
```
```ts
s[`--orientation-${orientation}`]                  /* only children are accessed */
```

A used child (direct, literal, or covered by the existing dynamic-coverage matching) now **rescues every ancestor** on its concatenation path. Works for dash (`&-x`), camelCase (`&Black`), and multi-level chains. Fully-unused families and genuinely-unused siblings are **still reported**.

### Problem 2 — whole CSS module passed to a function
When the imported module object is a direct argument to any function call — including the dominant composed form `classNames(s.root, responsiveClassNames(s, "--x", v))` — the analyzer cannot know which classes the function applies. That module is now **ignored** for both the unused and non-existent checks, with a distinct warning naming the source file and reason. Passing a single property (`classNames(s.root, …)`) or reading the module directly (`s.foo` / `s["foo"]` / `` s[`foo-${x}`] ``) does **not** trigger it; only the specific module passed whole is ignored, scoped per-module. `--no-dynamic` escalates it to an error; `--remove` never touches it.

Both behaviors are **configless**.

## Result on reshaped

Before: 13 "unused" (mostly false) + several false "non-existent". After: only **genuine** findings remain — `FormControl .root` (truly unused) and 5 real non-existent refs (Toast `.icon`/`.toast`, Select `.option`, Calendar `.row`). All previously-false `--orientation`/`--variant`/`--size`/`--nowrap`/`--full-width`/… are gone.

## How

| File | Change |
|------|--------|
| `extractCssClassAncestry.ts` (new) | child→parent map from CSS structure (via the existing `&` resolver, not prefix matching) |
| `rescueUsedAncestors.ts` (new) | append-only, terminating ancestor climb |
| `detectModulePassedToFunction.ts` (new) | AST predicate: import binding as a direct `CallExpression` argument |
| `types.ts` | new `ModuleIgnoredResult` status |
| `printResults.ts` | new distinct warning branch (yellow; red error under `--no-dynamic`) |
| `getUnusedClassesFromCss.ts`, `getNonExistentClassesFromCss.ts`, `index.ts` | wiring + exit-code |

## Tests

Test-first (TDD): each behavior had a failing test before implementation. **55 new tests** (isolated unit tests for the ancestry map, the rescue climb, and the detection predicate + 16 end-to-end fixtures covering all 6 user stories, the composed-handoff form, mixed-file, multi-module scoping, `--no-dynamic`, and `--remove`). Full suite: **847 pass, 0 fail**; biome lint/format and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)