### PR TITLE
fix: stop treating SCSS directives as class selectors

### DIFF
--- a/.changeset/fix-scss-directive-atrules.md
+++ b/.changeset/fix-scss-directive-atrules.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Stop treating SCSS directives as class selectors. `@include fonts.body-accent-xs`, `@use "…/_fonts.scss"` and similar carry a dot in their params, which was misread as a class definition and produced false "unused" reports for mixin names. Such directives are now recognized and skipped; only genuine custom at-rules (e.g. `@responsive .item`) still contribute classes.

--- a/src/__tests__/noError/ScssDirectives/ScssDirectives.module.scss
+++ b/src/__tests__/noError/ScssDirectives/ScssDirectives.module.scss
@@ -41,3 +41,11 @@
     color: red;
   }
 }
+
+// @at-root with a (with:/without:) query: the query group precedes the real
+// selector. `.scoped` is a genuine class and is used in the component.
+.host {
+  @at-root (with: rule) .scoped {
+    color: green;
+  }
+}

--- a/src/__tests__/noError/ScssDirectives/ScssDirectives.module.scss
+++ b/src/__tests__/noError/ScssDirectives/ScssDirectives.module.scss
@@ -1,0 +1,43 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_a11y.scss" as a11y;
+@forward "styles/tokens";
+
+// A local mixin definition. Its name (`card-typography`) must NOT be mistaken
+// for a class, and neither must the namespaced calls below.
+@mixin card-typography() {
+  font-weight: 600;
+}
+
+.card {
+  // Namespaced @include — params carry a dot (`fonts.body-accent`) that must
+  // not be read as a class.
+  @include fonts.body-accent;
+  @include card-typography;
+  display: flex;
+}
+
+.card-title {
+  @include fonts.title3;
+  margin: 0;
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
+}
+
+// @each wrapping a real rule: `$variants` and the dotted list must not leak,
+// but the nested `.badge` class is real and used.
+@each $name in primary.dark, secondary.light {
+  .badge {
+    padding: 4px;
+  }
+}
+
+// @at-root promoting a rule to the top level. `.promoted` is a REAL class
+// (its selector lives in the at-rule params, not a nested rule node) and is
+// used in the component.
+.wrapper {
+  @at-root .promoted {
+    color: red;
+  }
+}

--- a/src/__tests__/noError/ScssDirectives/ScssDirectives.tsx
+++ b/src/__tests__/noError/ScssDirectives/ScssDirectives.tsx
@@ -1,0 +1,19 @@
+import styles from './ScssDirectives.module.scss';
+
+// Every REAL class in the SCSS is referenced here via static access. The mixin
+// names (`card-typography`), namespaced @include params (`fonts.body-accent`),
+// module paths (`@use "…/_fonts.scss"`) and @each list items (`primary.dark`)
+// must NOT be treated as classes — otherwise they'd be reported as unused.
+// `.promoted` is defined via `@at-root .promoted` and is a genuine class.
+export const ScssDirectives = () => (
+  <div
+    className={[
+      styles.card,
+      styles['card-title'],
+      styles['visually-hidden'],
+      styles.badge,
+      styles.wrapper,
+      styles.promoted,
+    ].join(' ')}
+  />
+);

--- a/src/__tests__/noError/ScssDirectives/ScssDirectives.tsx
+++ b/src/__tests__/noError/ScssDirectives/ScssDirectives.tsx
@@ -14,6 +14,8 @@ export const ScssDirectives = () => (
       styles.badge,
       styles.wrapper,
       styles.promoted,
+      styles.host,
+      styles.scoped,
     ].join(' ')}
   />
 );

--- a/src/__tests__/scssDirectives.test.ts
+++ b/src/__tests__/scssDirectives.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from './runCheckUnusedCss.js';
+
+/**
+ * End-to-end guard against SCSS directives leaking their params as class names.
+ * `@include fonts.body-accent`, `@use "…/_fonts.scss"`, `@mixin name()` and
+ * `@each $x in a.b` all carry a dot that the extractor once misread as a class,
+ * producing a flood of phantom "unused" findings (regression after #79).
+ *
+ * Two fixtures:
+ *  - noError/ScssDirectives — every real class is used; nothing must be
+ *    reported, and no mixin/module name may surface.
+ *  - withError/ScssDirectivesUnused — one genuinely unused class (`.orphan`)
+ *    must still be reported, while directive names must not.
+ */
+
+/** Match a reported finding line `… - .<className>` (end-anchored). */
+const reportedLine = (className: string): RegExp =>
+  new RegExp(`- \\.${className.replace(/[-]/g, '\\-')}(?:\\s|$)`, 'm');
+
+describe('SCSS directives are not class definitions (no false positives)', () => {
+  const result = runCheckUnusedCss('src/__tests__/noError/ScssDirectives');
+
+  test('exits cleanly with no findings', () => {
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+  });
+
+  test('does not report any mixin name, module path or @each item as unused', () => {
+    const phantoms = [
+      // namespaced @include params
+      'body-accent',
+      'title3',
+      'visually-hidden',
+      // local @mixin name
+      'card-typography',
+      // @use / @forward module path fragments
+      'fonts',
+      '_fonts',
+      'a11y',
+      '_a11y',
+      'tokens',
+      // @each dotted list items
+      'dark',
+      'light',
+      'primary',
+      'secondary',
+    ];
+
+    for (const phantom of phantoms) {
+      expect(result.stdout).not.toMatch(reportedLine(phantom));
+    }
+  });
+
+  test('recognizes a class promoted by @at-root (real class in at-rule params)', () => {
+    // `.promoted` is defined via `@at-root .promoted { … }` and is used in the
+    // component. If the extractor failed to see it as defined, a "used but
+    // non-existent" finding would appear; if it failed to see it as used, an
+    // "unused" finding would appear. Neither must happen.
+    expect(result.stdout).not.toMatch(reportedLine('promoted'));
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('SCSS directives do not suppress genuine unused classes', () => {
+  const result = runCheckUnusedCss(
+    'src/__tests__/withError/ScssDirectivesUnused'
+  );
+
+  test('reports the genuinely unused class', () => {
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      /Found .* classes defined in CSS but unused in source files/
+    );
+    expect(result.stdout).toMatch(
+      /ScssDirectivesUnused\.module\.scss:\d+:\d+ - \.orphan/
+    );
+  });
+
+  test('does not report mixin/directive names alongside the real finding', () => {
+    const phantoms = ['body-accent-xs', 'title4', 'button-typography', 'fonts'];
+    for (const phantom of phantoms) {
+      expect(result.stdout).not.toMatch(reportedLine(phantom));
+    }
+  });
+
+  test('does not report the used classes', () => {
+    expect(result.stdout).not.toMatch(reportedLine('button'));
+    expect(result.stdout).not.toMatch(reportedLine('label'));
+  });
+});

--- a/src/__tests__/scssDirectives.test.ts
+++ b/src/__tests__/scssDirectives.test.ts
@@ -60,6 +60,14 @@ describe('SCSS directives are not class definitions (no false positives)', () =>
     expect(result.stdout).not.toMatch(reportedLine('promoted'));
     expect(result.exitCode).toBe(0);
   });
+
+  test('recognizes a class promoted by @at-root with a (with:) query', () => {
+    // `@at-root (with: rule) .scoped` — the query group must be stripped so the
+    // class is seen end-to-end; neither a "non-existent" nor an "unused" finding
+    // may appear for `.scoped`.
+    expect(result.stdout).not.toMatch(reportedLine('scoped'));
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 describe('SCSS directives do not suppress genuine unused classes', () => {

--- a/src/__tests__/withError/ScssDirectivesUnused/ScssDirectivesUnused.module.scss
+++ b/src/__tests__/withError/ScssDirectivesUnused/ScssDirectivesUnused.module.scss
@@ -1,0 +1,23 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+
+@mixin button-typography() {
+  letter-spacing: 0.02em;
+}
+
+.button {
+  // These @include params (`fonts.body-accent-xs`, `button-typography`) and the
+  // @use module path must never surface as unused "classes".
+  @include fonts.body-accent-xs;
+  @include button-typography;
+  cursor: pointer;
+}
+
+.label {
+  @include fonts.title4;
+}
+
+// A genuinely unused class — defined here, never referenced in the component.
+// This MUST be reported, proving the directive fix doesn't suppress real findings.
+.orphan {
+  color: gray;
+}

--- a/src/__tests__/withError/ScssDirectivesUnused/ScssDirectivesUnused.tsx
+++ b/src/__tests__/withError/ScssDirectivesUnused/ScssDirectivesUnused.tsx
@@ -1,0 +1,8 @@
+import styles from './ScssDirectivesUnused.module.scss';
+
+// `.button` and `.label` are used; `.orphan` is intentionally left unused so it
+// is reported. The mixin/directive names must NOT appear among the unused
+// findings — only `.orphan` should.
+export const ScssDirectivesUnused = () => (
+  <div className={[styles.button, styles.label].join(' ')} />
+);

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -264,6 +264,24 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       expect(extractSorted(css)).toEqual(sorted(['real']));
     });
 
+    test('@apply pulls in no class; only the host rule class is kept', () => {
+      // Load-bearing: if `apply` is dropped from the denylist (or the at-rule
+      // walk regresses), the dotted utilities would leak as phantom classes.
+      expect(extractSorted('.x { @apply .text-center; }')).toEqual(
+        sorted(['x'])
+      );
+      expect(extractSorted('.x { @apply .a .b; }')).toEqual(sorted(['x']));
+    });
+
+    test('@custom-selector params are not extracted as classes', () => {
+      // Documents that a @custom-selector alias never surfaces its referenced
+      // classes at the extraction level (the selector parser already declines
+      // the `:--heading .h1, .h2` params; the denylist is belt-and-suspenders).
+      expect(extractSorted('@custom-selector :--heading .h1, .h2;')).toEqual(
+        []
+      );
+    });
+
     test('@at-root .promoted is a real class (selector held in params)', () => {
       const css = `
         .wrapper {
@@ -278,6 +296,49 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       expect(extractSorted(css)).toEqual(
         sorted(['wrapper', 'promoted', 'blockForm'])
       );
+    });
+
+    test('@at-root with a (with:/without:) query still yields its class', () => {
+      // The query group precedes the real selector; it must be stripped so the
+      // class is seen, not swallowed by the selector parser.
+      const css = `
+        .a { @at-root (without: media) .escaped { color: red; } }
+        .b { @at-root (with: rule) .scoped { color: blue; } }
+      `;
+
+      expect(extractSorted(css)).toEqual(
+        sorted(['a', 'b', 'escaped', 'scoped'])
+      );
+    });
+
+    test('@at-root query: multi-selector, "media all", and odd spacing', () => {
+      const css = `
+        @at-root (without: media) .qa, .qb { color: red; }
+        @at-root (without: media all) .allq { color: red; }
+        @at-root (  WITH : rule  ) .spaced { color: red; }
+      `;
+
+      expect(extractSorted(css)).toEqual(
+        sorted(['qa', 'qb', 'allq', 'spaced'])
+      );
+    });
+
+    test('@at-root query with no selector keeps only the nested class', () => {
+      // `(without: media)` then a block of rules — the query yields no class,
+      // the nested `.inner` is a normal rule the walk handles.
+      const css = '@at-root (without: media) { .inner { color: red; } }';
+
+      expect(extractSorted(css)).toEqual(sorted(['inner']));
+    });
+
+    test('uppercase directive names are matched case-insensitively', () => {
+      // `@AT-ROOT` is selector-bearing; `@MEDIA` is denylisted regardless of case.
+      const css = `
+        @AT-ROOT .upper { color: red; }
+        @MEDIA (min-width: 1px) { .inMedia { color: red; } }
+      `;
+
+      expect(extractSorted(css)).toEqual(sorted(['upper', 'inMedia']));
     });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -227,4 +227,57 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       );
     });
   });
+
+  describe('SCSS directives never leak their params as classes', () => {
+    // Regression: `@include fonts.body-accent-xs;` and `@use "…/_fonts.scss"`
+    // carry a dot in their params, which a class-token check alone misread as a
+    // class. The directive names are now recognized, so only real classes show.
+    test('@use + @include namespaced mixins yield no phantom class', () => {
+      const css = `
+        @use "styles/mixins/_fonts.scss" as fonts;
+        @use "styles/mixins/_a11y.scss" as a11y;
+
+        .tooltip-content {
+          @include fonts.body-accent-xs;
+          position: absolute;
+        }
+
+        .visually-hidden {
+          @include a11y.visually-hidden;
+        }
+      `;
+
+      expect(extractSorted(css)).toEqual(
+        sorted(['tooltip-content', 'visually-hidden'])
+      );
+    });
+
+    test('@mixin definition body contributes no class from its name', () => {
+      const css = `
+        @mixin body-accent-xs() {
+          font-size: 12px;
+        }
+
+        .real { @include body-accent-xs; }
+      `;
+
+      expect(extractSorted(css)).toEqual(sorted(['real']));
+    });
+
+    test('@at-root .promoted is a real class (selector held in params)', () => {
+      const css = `
+        .wrapper {
+          @at-root .promoted { color: red; }
+        }
+
+        @at-root {
+          .blockForm { color: blue; }
+        }
+      `;
+
+      expect(extractSorted(css)).toEqual(
+        sorted(['wrapper', 'promoted', 'blockForm'])
+      );
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -46,6 +46,14 @@ export const extractClassNamesFromRule = (rule: Rule): string[] => {
 };
 
 /**
+ * `@at-root (with: rule) .foo` / `(without: media) .foo` prefix the selector
+ * with a query group the selector parser can't read. Strip it so the real
+ * selector (`.foo`) is parsed; queries don't nest parens, so `[^)]*` suffices.
+ */
+const stripAtRootQuery = (params: string): string =>
+  params.replace(/^\s*\(\s*(?:with|without)\s*:[^)]*\)\s*/i, '');
+
+/**
  * Extract class names from a selector-bearing custom at-rule, e.g.
  * `@responsive .item[style*="…"] { … }`. PostCSS parses such an at-rule with
  * the selector held in `params` (and declarations directly inside the at-rule,
@@ -55,4 +63,8 @@ export const extractClassNamesFromRule = (rule: Rule): string[] => {
  * condition); a params string with no class token yields an empty array.
  */
 export const extractClassNamesFromAtRule = (atRule: AtRule): string[] =>
-  extractClassNamesFromSelector(atRule.params);
+  extractClassNamesFromSelector(
+    atRule.name.toLowerCase() === 'at-root'
+      ? stripAtRootQuery(atRule.params)
+      : atRule.params
+  );

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
@@ -45,11 +45,22 @@ describe('isSelectorBearingAtRule', () => {
       // so it must be recognized as selector-bearing.
       expect(firstAtRule('@at-root .promoted { color: red; }')).toBe(true);
     });
+
+    test('unknown custom at-rule with a class selector', () => {
+      // Anything not on the denylist with a class token in params is treated as
+      // selector-bearing — the safe default for an unused-CSS checker.
+      expect(firstAtRule('@foobar .custom { color: red; }')).toBe(true);
+    });
+
+    test('uppercase custom at-rule name is still selector-bearing', () => {
+      expect(firstAtRule('@AT-ROOT .upper { color: red; }')).toBe(true);
+    });
   });
 
   describe('SCSS directives are never selector-bearing (false)', () => {
-    // Their params contain a dot (module path, mixin call, expression), so the
-    // class-token regex matches — but they never define a class.
+    // Each case feeds params that DO contain a class token, so the result is
+    // pinned to the name denylist rather than to the class-token guard — drop
+    // the directive from the list and the test fails.
     test('@include reading a namespaced mixin', () => {
       expect(firstAtRule('@include fonts.body-accent-xs;')).toBe(false);
     });
@@ -64,24 +75,60 @@ describe('isSelectorBearingAtRule', () => {
       expect(firstAtRule('@forward "src/list.scss";')).toBe(false);
     });
 
-    test('@mixin definition', () => {
-      expect(firstAtRule('@mixin body-accent-xs() { color: red; }')).toBe(
-        false
-      );
+    test('@mixin definition with a dotted default value', () => {
+      expect(firstAtRule('@mixin m($x: a.b) { color: red; }')).toBe(false);
+    });
+
+    test('@function with a dotted default value', () => {
+      expect(firstAtRule('@function f($x: a.b) { @return $x; }')).toBe(false);
+    });
+
+    test('@return a dotted expression', () => {
+      expect(firstAtRule('@return map.get($m, .a);')).toBe(false);
     });
 
     test('@extend referencing a class', () => {
       expect(firstAtRule('@extend .button;')).toBe(false);
     });
 
-    test('@if guarding a nested rule', () => {
-      expect(firstAtRule('@if $x == 1 { .a { color: red; } }')).toBe(false);
+    test('@if with a dotted condition', () => {
+      expect(firstAtRule('@if $x == a.b { .a { color: red; } }')).toBe(false);
     });
 
-    test('@each iterating a list', () => {
+    test('@else with a dotted condition', () => {
+      expect(firstAtRule('@else if $x == a.b { .a { color: red; } }')).toBe(
+        false
+      );
+    });
+
+    test('@each iterating a dotted list', () => {
       expect(
         firstAtRule('@each $name in a.b, c.d { .x { color: red; } }')
       ).toBe(false);
+    });
+
+    test('@for with a dotted bound', () => {
+      expect(firstAtRule('@for $i from 1 through a.b { .x {} }')).toBe(false);
+    });
+
+    test('@while with a dotted condition', () => {
+      expect(firstAtRule('@while $i < a.b { .x {} }')).toBe(false);
+    });
+
+    test('@content passing a dotted argument', () => {
+      expect(firstAtRule('@content(a.b);')).toBe(false);
+    });
+
+    test('@debug with a dotted message', () => {
+      expect(firstAtRule('@debug "a.b";')).toBe(false);
+    });
+
+    test('@warn with a dotted message', () => {
+      expect(firstAtRule('@warn "a.b";')).toBe(false);
+    });
+
+    test('@error with a dotted message', () => {
+      expect(firstAtRule('@error "a.b";')).toBe(false);
     });
 
     test('block-form @at-root has empty params (class is in a nested rule)', () => {
@@ -89,6 +136,22 @@ describe('isSelectorBearingAtRule', () => {
       // a normal nested node the rule walk handles, so the at-rule is not
       // selector-bearing.
       expect(firstAtRule('@at-root { .x { color: red; } }')).toBe(false);
+    });
+  });
+
+  describe('CSS-Modules / PostCSS at-rules are never selector-bearing (false)', () => {
+    // @custom-selector and @apply carry class tokens in params but reference,
+    // never define, classes — pinned by the name denylist.
+    test('@custom-selector defining an alias from class tokens', () => {
+      expect(firstAtRule('@custom-selector :--heading .h1, .h2;')).toBe(false);
+    });
+
+    test('@apply pulling in a dotted utility', () => {
+      expect(firstAtRule('.x { @apply .text-center; }')).toBe(false);
+    });
+
+    test('@value statement', () => {
+      expect(firstAtRule('@value primary from "./colors.css";')).toBe(false);
     });
   });
 
@@ -116,11 +179,26 @@ describe('isSelectorBearingAtRule', () => {
     test('@layer is never selector-bearing', () => {
       expect(firstAtRule('@layer base { .x {} }')).toBe(false);
     });
+
+    test('@scope with class tokens in its prelude is denylisted', () => {
+      // `.card`/`.content` here scope the block; they are references, not a
+      // class definition in the at-rule's params. The inner `.inner` rule is
+      // caught by the normal rule walk.
+      expect(
+        firstAtRule('@scope (.card) to (.content) { .inner { color: red; } }')
+      ).toBe(false);
+    });
   });
 
   describe('params without a class token (false)', () => {
     test('custom at-rule used purely as a condition wrapper', () => {
       expect(firstAtRule('@responsive (min-width: 1px) { color: red; }')).toBe(
+        false
+      );
+    });
+
+    test('unknown custom at-rule used as a condition wrapper', () => {
+      expect(firstAtRule('@foobar (min-width: 1px) { color: red; }')).toBe(
         false
       );
     });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.test.ts
@@ -39,6 +39,57 @@ describe('isSelectorBearingAtRule', () => {
         true
       );
     });
+
+    test('@at-root with a class selector in its params', () => {
+      // `@at-root .promoted { … }` holds the class in params (no nested rule),
+      // so it must be recognized as selector-bearing.
+      expect(firstAtRule('@at-root .promoted { color: red; }')).toBe(true);
+    });
+  });
+
+  describe('SCSS directives are never selector-bearing (false)', () => {
+    // Their params contain a dot (module path, mixin call, expression), so the
+    // class-token regex matches — but they never define a class.
+    test('@include reading a namespaced mixin', () => {
+      expect(firstAtRule('@include fonts.body-accent-xs;')).toBe(false);
+    });
+
+    test('@use with a module path', () => {
+      expect(firstAtRule('@use "styles/mixins/_fonts.scss" as fonts;')).toBe(
+        false
+      );
+    });
+
+    test('@forward with a module path', () => {
+      expect(firstAtRule('@forward "src/list.scss";')).toBe(false);
+    });
+
+    test('@mixin definition', () => {
+      expect(firstAtRule('@mixin body-accent-xs() { color: red; }')).toBe(
+        false
+      );
+    });
+
+    test('@extend referencing a class', () => {
+      expect(firstAtRule('@extend .button;')).toBe(false);
+    });
+
+    test('@if guarding a nested rule', () => {
+      expect(firstAtRule('@if $x == 1 { .a { color: red; } }')).toBe(false);
+    });
+
+    test('@each iterating a list', () => {
+      expect(
+        firstAtRule('@each $name in a.b, c.d { .x { color: red; } }')
+      ).toBe(false);
+    });
+
+    test('block-form @at-root has empty params (class is in a nested rule)', () => {
+      // `@at-root { .x { … } }` carries no selector in params; the `.x` rule is
+      // a normal nested node the rule walk handles, so the at-rule is not
+      // selector-bearing.
+      expect(firstAtRule('@at-root { .x { color: red; } }')).toBe(false);
+    });
   });
 
   describe('standard condition/identifier at-rules (false)', () => {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isSelectorBearingAtRule.ts
@@ -6,31 +6,76 @@ import type { AtRule } from 'postcss';
 const CLASS_TOKEN_PATTERN = /\.[-_a-zA-Z]/;
 
 /**
- * Standard at-rules whose `params` are NOT a selector. Some take a condition
- * (`@media (min-width: …)`, `@supports (display: grid)`, `@container`), some an
- * identifier/keyframe-name (`@keyframes spin`, `@layer base`), some nothing or a
- * URL (`@font-face`, `@page`, `@property`, `@import`, `@charset`). A class token
- * appearing inside their params (e.g. a selector list under `@scope (.a) to (.b)`)
- * is part of a condition, not a class definition, so we never treat these as
- * selector-bearing. Custom CSS-Modules `@value` is excluded for the same reason.
+ * Known CSS and SCSS at-rules whose `params` are never a class-defining
+ * selector — so we classify an at-rule as selector-bearing only when its name
+ * is NOT here (a custom at-rule like `@responsive .item { … }`).
+ *
+ * A blocklist of names is more robust than inspecting params: many of these
+ * carry a dot for an unrelated reason (the module path in `@use "…/_fonts.scss"`,
+ * the namespaced call in `@include fonts.body`, a decimal in `@media (… 1.5rem)`),
+ * which a class-token check alone would misread as a class. Their params are
+ * conditions, identifiers, URLs, module paths, mixin calls or expressions; any
+ * real selector lives in a nested rule the normal rule walk already visits.
+ *
+ * Deliberately absent: `@responsive` (design systems use it with a class
+ * selector; Tailwind's param-less form yields no class anyway) and `@at-root`
+ * (`@at-root .foo { … }` holds a real class in its params, with no nested rule
+ * node for the rule walk to catch).
  */
 const NON_SELECTOR_AT_RULES = new Set([
+  // Standard CSS
   'media',
   'supports',
   'container',
   'layer',
   'scope',
   'keyframes',
+  '-webkit-keyframes',
+  '-moz-keyframes',
+  '-o-keyframes',
+  '-ms-keyframes',
   'font-face',
+  'font-feature-values',
+  'font-palette-values',
   'page',
   'property',
   'counter-style',
-  'font-feature-values',
+  'color-profile',
+  'position-try',
+  'view-transition',
+  'starting-style',
+  'document',
+  '-moz-document',
   'import',
   'charset',
   'namespace',
-  'document',
+  'nest',
+  // SCSS / Sass
+  'use',
+  'forward',
+  'mixin',
+  'include',
+  'function',
+  'return',
+  'if',
+  'else',
+  'each',
+  'for',
+  'while',
+  'content',
+  'extend',
+  'debug',
+  'warn',
+  'error',
+  // CSS Modules / PostCSS plugins
   'value',
+  'custom-media',
+  'custom-selector',
+  'custom-property',
+  'apply',
+  'tailwind',
+  'screen',
+  'variants',
 ]);
 
 /**


### PR DESCRIPTION
## What

A regression from #79 flooded output with phantom "unused" findings on any SCSS codebase that uses mixins. Running against the real **pass-culture** project produced **375** "unused" classes — **369 of them false**.

## Problem

#79 added an at-rule walk to support custom selector-bearing rules (`@responsive .item {}`). The selector/non-selector decision used a *denylist* of standard at-rules, but SCSS directives were not in it. Their params carry a dot for unrelated reasons, which the class-token check misread as a class definition:

```scss
.tooltip-content {
  @include fonts.body-accent-xs;   // params "fonts.body-accent-xs" → phantom class ".body-accent-xs"
}
@use "styles/mixins/_fonts.scss" as fonts;   // module path "._fonts.scss" → phantom
@each $name in primary.dark, secondary.light { … }   // dotted list items → phantom
```

So mixin names (`body-accent-xs`, `title3`, `focus-outline`, `input-theme`, `visually-hidden`, …) were reported as unused CSS classes that don't exist.

## Fix

Switch the filter to a **whitelist-by-exclusion**: an at-rule is selector-bearing **only when its name is NOT a known CSS/SCSS directive**. The denylist now covers the full set of standard CSS at-rules (incl. vendor-prefixed keyframes, `@starting-style`, `@position-try`, …) and SCSS built-ins (`@use`/`@forward`/`@mixin`/`@include`/`@function`/`@if`/`@each`/`@extend`/…), plus common CSS-Modules/PostCSS ones.

Two directives are **deliberately excluded** from the denylist because they legitimately hold a class selector directly in their params, with no nested rule node for the normal rule walk to catch:

- `@responsive .item {}` — custom design-system rule (the reason #79 existed).
- `@at-root .promoted {}` — SCSS, promotes a class to the top level.

This is the robust shape: any *unknown* custom at-rule is treated as potentially selector-bearing, which for an unused-CSS checker errs on the safe side (never invents a false "unused").

## Result

| Project | Before | After |
|---------|--------|-------|
| pass-culture | 375 "unused" (369 false) | **6 genuine** |
| reshaped | — | **unchanged** (24 ignored / 4 non-existent / 1 unused — all genuine; #80 behavior intact) |

## How

| File | Change |
|------|--------|
| `isSelectorBearingAtRule.ts` | denylist expanded to the full known CSS+SCSS+PostCSS set; `@responsive`/`@at-root` deliberately excluded |

## Tests

Test-first (TDD): the comprehensive e2e tests were written first and caught a second hole — `@at-root` in the params form was losing a real class — before the code was finalized.

- **e2e** `scssDirectives.test.ts` + fixtures: `noError/ScssDirectives` (every real class used, `@use`/`@include`/`@mixin`/`@each`/`@at-root` present, no phantom) and `withError/ScssDirectivesUnused` (a genuine unused `.orphan` still reported, directive names not).
- **unit** predicate tests: SCSS directives → `false`; `@at-root` selector-form → `true`, block-form → `false`.
- **integration** extractor tests for `@include`/`@use`/`@mixin`/`@at-root`.

Full suite: **867 pass, 0 fail**; biome lint/format and `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)