### PR TITLE
fix: stop false "non-existent" for locally-composed classes (#83)

### DIFF
--- a/.changeset/fix-composes-local-target.md
+++ b/.changeset/fix-composes-local-target.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Fix a false "non-existent" report for a local class that is also used via `composes:` (#83). A class defined in the same file and referenced as `composes: localClass` was dropped from the defined set, so reading `styles.localClass` looked like a missing class. Such targets are now kept and counted as used; `composes: x from '…'` / `from global` are still treated as external.

--- a/src/__tests__/falsePositives/ComposesFromExternal/ComposesFromExternal.module.css
+++ b/src/__tests__/falsePositives/ComposesFromExternal/ComposesFromExternal.module.css
@@ -1,0 +1,5 @@
+.card {
+  composes: base from './shared.module.css';
+  composes: highlight from global;
+  border: 1px solid;
+}

--- a/src/__tests__/falsePositives/ComposesFromExternal/ComposesFromExternal.tsx
+++ b/src/__tests__/falsePositives/ComposesFromExternal/ComposesFromExternal.tsx
@@ -1,0 +1,8 @@
+import styles from './ComposesFromExternal.module.css';
+
+// `.card` composes from an external module and from global. Those targets
+// (`base`, `highlight`) are not local classes and must not leak as defined
+// classes. `.card` is used directly, so the run must be clean.
+export const ComposesFromExternal = () => (
+  <div className={styles.card}>Hello</div>
+);

--- a/src/__tests__/falsePositives/ComposesLocalDirectUse/ComposesLocalDirectUse.module.css
+++ b/src/__tests__/falsePositives/ComposesLocalDirectUse/ComposesLocalDirectUse.module.css
@@ -1,0 +1,8 @@
+.definedClass {
+  color: red;
+}
+
+.composingClass {
+  composes: definedClass;
+  font-size: 14px;
+}

--- a/src/__tests__/falsePositives/ComposesLocalDirectUse/ComposesLocalDirectUse.tsx
+++ b/src/__tests__/falsePositives/ComposesLocalDirectUse/ComposesLocalDirectUse.tsx
@@ -1,0 +1,8 @@
+import styles from './ComposesLocalDirectUse.module.css';
+
+// Issue #83: `.definedClass` is a real local class, also composed into
+// `.composingClass`. Reading `styles.definedClass` must resolve (not be flagged
+// "non-existent"). Only `.composingClass` — never used in code — is unused.
+export const ComposesLocalDirectUse = () => (
+  <div className={styles.definedClass}>Hello</div>
+);

--- a/src/__tests__/falsePositives/ComposesLocalIndirectUse/ComposesLocalIndirectUse.module.css
+++ b/src/__tests__/falsePositives/ComposesLocalIndirectUse/ComposesLocalIndirectUse.module.css
@@ -1,0 +1,12 @@
+.base {
+  padding: 8px;
+}
+
+.button {
+  composes: base;
+  color: blue;
+}
+
+.orphan {
+  color: green;
+}

--- a/src/__tests__/falsePositives/ComposesLocalIndirectUse/ComposesLocalIndirectUse.tsx
+++ b/src/__tests__/falsePositives/ComposesLocalIndirectUse/ComposesLocalIndirectUse.tsx
@@ -1,0 +1,7 @@
+import styles from './ComposesLocalIndirectUse.module.css';
+
+// `.button` is used directly and composes `.base`. `.base` is referenced only
+// via `composes` — it must count as used, not unused. Only `.orphan` is unused.
+export const ComposesLocalIndirectUse = () => (
+  <div className={styles.button}>Hello</div>
+);

--- a/src/__tests__/falsePositives/composes.test.ts
+++ b/src/__tests__/falsePositives/composes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from '../runCheckUnusedCss.js';
+
+const run = (folder: string) =>
+  runCheckUnusedCss(`src/__tests__/falsePositives/${folder}`);
+
+// A reported finding renders as `  <file>:<line>:<col> - .<class>\n`. To assert
+// a class is NOT reported we must anchor to the end of the token, otherwise
+// ` - .base` would also match a longer ` - .baseButton` line.
+const reportedLine = (cls: string): RegExp =>
+  new RegExp(` - \\.${cls.replace(/[-]/g, '\\$&')}(?:\\n|$)`);
+
+describe('false positives — CSS Modules composes (issue #83)', () => {
+  test('ComposesLocalDirectUse: a directly-used composed target is not non-existent', () => {
+    const result = run('ComposesLocalDirectUse');
+
+    expect(result.exitCode).toBe(1);
+
+    // `.definedClass` is a real local class also referenced by `composes`. A
+    // direct `styles.definedClass` read must resolve — never "non-existent".
+    expect(result.stderr).not.toMatch(/non-existent/);
+    expect(result.stdout).not.toMatch(
+      /ComposesLocalDirectUse\.tsx:\d+:\d+ - \.definedClass\b/
+    );
+
+    // `.composingClass` is never used in code → the only genuine unused class.
+    expect(result.stdout).toMatch(
+      /ComposesLocalDirectUse\.module\.css:\d+:\d+ - \.composingClass\b/
+    );
+  });
+
+  test('ComposesLocalIndirectUse: a composed-only target is used, orphan still reported', () => {
+    const result = run('ComposesLocalIndirectUse');
+
+    expect(result.exitCode).toBe(1);
+
+    // `.base` is referenced only via `composes` from the used `.button`. It must
+    // count as used (not unused) and must exist (not non-existent).
+    expect(result.stderr).not.toMatch(/non-existent/);
+    expect(result.stdout).not.toMatch(reportedLine('base'));
+    expect(result.stdout).not.toMatch(reportedLine('button'));
+
+    // `.orphan` is genuinely unused.
+    expect(result.stdout).toMatch(
+      /ComposesLocalIndirectUse\.module\.css:\d+:\d+ - \.orphan\b/
+    );
+  });
+
+  test('ComposesFromExternal: external/global composes targets do not leak', () => {
+    const result = run('ComposesFromExternal');
+
+    // `.card` is used directly; `base`/`highlight` are external and must not be
+    // extracted as defined classes, so the run is clean.
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+    expect(result.stderr).not.toMatch(/non-existent/);
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
+++ b/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
@@ -12,13 +12,14 @@ import {
 } from './utils/coverage/index.js';
 import {
   type ClassAncestry,
+  extractComposedClassesFromContent,
   extractCssClassAncestry,
   extractCssClassesWithLocations,
 } from './utils/extractCssClasses/index.js';
-import { rescueUsedAncestors } from './utils/rescueUsedAncestors.js';
 import { extractUsedClasses } from './utils/extractUsedClasses.js';
 import { findFilesImportingCssModule } from './utils/findFilesImportingCssModule/index.js';
 import { detectModulePassedToFunction } from './utils/passedToFunction/detectModulePassedToFunction.js';
+import { rescueUsedAncestors } from './utils/rescueUsedAncestors.js';
 
 type GetUnusedClassesFromCssParams = {
   cssFile: string;
@@ -38,6 +39,10 @@ export const getUnusedClassesFromCss = async ({
     return null;
   }
 
+  // A class used only via `composes:` (never read in code) still counts as
+  // used — seed it so it isn't reported as unused.
+  const composedClasses = extractComposedClassesFromContent(cssContent);
+
   const importingFilesData = await findFilesImportingCssModule(cssFile, srcDir);
 
   if (importingFilesData.length === 0) {
@@ -47,7 +52,7 @@ export const getUnusedClassesFromCss = async ({
     };
   }
 
-  const usedClasses = new Set<string>();
+  const usedClasses = new Set<string>(composedClasses);
   const allAccesses: ClassAccess[] = [];
 
   for (const importingFileData of importingFilesData) {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
@@ -1,7 +1,6 @@
 import postcssScss from 'postcss-scss';
 import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
 import { extractClassNamesFromSelector } from './utils/extractClassNamesFromRule.js';
-import { extractComposedClasses } from './utils/extractComposedClasses.js';
 import {
   getParentClassName,
   resolveAmpersandSelector,
@@ -67,13 +66,6 @@ export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
       }
     }
   });
-
-  // A class removed because it is `composes:`-d from elsewhere is not a real
-  // family member here, so it must not be able to rescue a parent.
-  const composedClasses = extractComposedClasses(root);
-  for (const composedClassName of composedClasses) {
-    ancestry.delete(composedClassName);
-  }
 
   return ancestry;
 };

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.test.ts
@@ -9,15 +9,10 @@ import {
 } from 'bun:test';
 import { extractCssClasses } from './extractCssClasses.js';
 import * as extractClassNamesFromRuleModule from './utils/extractClassNamesFromRule.js';
-import * as extractComposedClassesModule from './utils/extractComposedClasses.js';
 
 describe('extractCssClasses', () => {
   let extractClassNamesFromRuleSpy: Mock<
     (typeof extractClassNamesFromRuleModule)['extractClassNamesFromRule']
-  >;
-
-  let extractComposedClassesSpy: Mock<
-    (typeof extractComposedClassesModule)['extractComposedClasses']
   >;
 
   beforeEach(() => {
@@ -25,29 +20,21 @@ describe('extractCssClasses', () => {
       extractClassNamesFromRuleModule,
       'extractClassNamesFromRule'
     ).mockReturnValue([]);
-
-    extractComposedClassesSpy = spyOn(
-      extractComposedClassesModule,
-      'extractComposedClasses'
-    ).mockReturnValue([]);
   });
 
   afterEach(() => {
     extractClassNamesFromRuleSpy.mockRestore();
-    extractComposedClassesSpy.mockRestore();
   });
 
   describe('should extract class names from CSS content', () => {
     test('extracts class names from single rule', () => {
       extractClassNamesFromRuleSpy.mockReturnValue(['container']);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = '.container { color: blue; }';
       const result = extractCssClasses(css);
 
       expect(result).toEqual(['container']);
       expect(extractClassNamesFromRuleSpy).toHaveBeenCalledTimes(1);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
 
     test('extracts class names from multiple rules', () => {
@@ -55,8 +42,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['container'])
         .mockReturnValueOnce(['button'])
         .mockReturnValueOnce(['text']);
-
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         .container { color: blue; }
@@ -67,7 +52,6 @@ describe('extractCssClasses', () => {
 
       expect(result).toEqual(['container', 'button', 'text']);
       expect(extractClassNamesFromRuleSpy).toHaveBeenCalledTimes(3);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
 
     test('extracts multiple class names from single rule', () => {
@@ -76,7 +60,6 @@ describe('extractCssClasses', () => {
         'active',
         'large',
       ]);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = '.container.active.large { color: blue; }';
       const result = extractCssClasses(css);
@@ -86,19 +69,14 @@ describe('extractCssClasses', () => {
     });
 
     test('handles empty CSS content', () => {
-      extractComposedClassesSpy.mockReturnValue([]);
-
       const css = '';
       const result = extractCssClasses(css);
 
       expect(result).toEqual([]);
       expect(extractClassNamesFromRuleSpy).not.toHaveBeenCalled();
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
 
     test('handles CSS without class rules', () => {
-      extractComposedClassesSpy.mockReturnValue([]);
-
       const css = `
         body { margin: 0; }
         h1 { font-size: 24px; }
@@ -108,7 +86,6 @@ describe('extractCssClasses', () => {
 
       expect(result).toEqual([]);
       expect(extractClassNamesFromRuleSpy).toHaveBeenCalledTimes(3);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -118,8 +95,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['container'])
         .mockReturnValueOnce(['container', 'button'])
         .mockReturnValueOnce(['button']);
-
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         .container { color: blue; }
@@ -138,7 +113,6 @@ describe('extractCssClasses', () => {
         'container',
         'button',
       ]);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = '.container { color: blue; }';
       const result = extractCssClasses(css);
@@ -154,8 +128,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['c', 'd', 'e'])
         .mockReturnValueOnce(['a', 'e']);
 
-      extractComposedClassesSpy.mockReturnValue([]);
-
       const css = `
         .a.b.c { color: blue; }
         .b.c.d { padding: 10px; }
@@ -169,14 +141,15 @@ describe('extractCssClasses', () => {
     });
   });
 
-  describe('should handle composed classes', () => {
-    test('removes composed classes from final result', () => {
+  describe('should keep locally-defined composed classes (issue #83)', () => {
+    // A class referenced by `composes:` that is also defined in this file is a
+    // real class — it must stay in the defined set so a direct read of it
+    // resolves. (Whether it is "unused" is decided later, not here.)
+    test('keeps a composed target that is defined in the file', () => {
       extractClassNamesFromRuleSpy
         .mockReturnValueOnce(['baseButton'])
         .mockReturnValueOnce(['primaryButton'])
         .mockReturnValueOnce(['secondaryButton']);
-
-      extractComposedClassesSpy.mockReturnValue(['baseButton']);
 
       const css = `
         .baseButton { padding: 10px; }
@@ -185,17 +158,19 @@ describe('extractCssClasses', () => {
       `;
       const result = extractCssClasses(css);
 
-      expect(result).toEqual(['primaryButton', 'secondaryButton']);
+      expect(result).toEqual([
+        'baseButton',
+        'primaryButton',
+        'secondaryButton',
+      ]);
       expect(extractClassNamesFromRuleSpy).toHaveBeenCalledTimes(3);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
 
-    test('removes multiple composed classes', () => {
+    test('keeps multiple composed targets that are defined in the file', () => {
       extractClassNamesFromRuleSpy
         .mockReturnValueOnce(['base', 'theme'])
         .mockReturnValueOnce(['button'])
         .mockReturnValueOnce(['input']);
-      extractComposedClassesSpy.mockReturnValue(['base', 'theme']);
 
       const css = `
         .base { margin: 0; }
@@ -205,40 +180,23 @@ describe('extractCssClasses', () => {
       `;
       const result = extractCssClasses(css);
 
-      expect(result).toEqual(['button', 'input']);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(['base', 'theme', 'button', 'input']);
     });
 
-    test('handles case where composed class is not in extracted classes', () => {
+    test('an external composes target is not invented as a defined class', () => {
       extractClassNamesFromRuleSpy
         .mockReturnValueOnce(['button'])
         .mockReturnValueOnce(['input']);
-      extractComposedClassesSpy.mockReturnValue(['nonExistentClass']);
 
+      // `external` lives in another module; it has no rule here, so it is never
+      // a defined class — and the `from`/path tokens must not leak either.
       const css = `
-        .button { padding: 10px; }
+        .button { composes: external from './other.module.css'; padding: 10px; }
         .input { margin: 5px; }
       `;
       const result = extractCssClasses(css);
 
       expect(result).toEqual(['button', 'input']);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
-    });
-
-    test('handles empty composed classes', () => {
-      extractClassNamesFromRuleSpy
-        .mockReturnValueOnce(['button'])
-        .mockReturnValueOnce(['input']);
-      extractComposedClassesSpy.mockReturnValue([]);
-
-      const css = `
-        .button { padding: 10px; }
-        .input { margin: 5px; }
-      `;
-      const result = extractCssClasses(css);
-
-      expect(result).toEqual(['button', 'input']);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -247,7 +205,6 @@ describe('extractCssClasses', () => {
       extractClassNamesFromRuleSpy
         .mockReturnValueOnce(['container'])
         .mockReturnValueOnce(['mobile']);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         .container { width: 100%; }
@@ -267,7 +224,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce([]) // from rule
         .mockReturnValueOnce([]) // to rule
         .mockReturnValueOnce(['animated']); // .animated rule
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         @keyframes fadeIn {
@@ -287,7 +243,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['container'])
         .mockReturnValueOnce(['dark'])
         .mockReturnValueOnce(['light']);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         .container { width: 100%; }
@@ -308,7 +263,6 @@ describe('extractCssClasses', () => {
   describe('should handle edge cases', () => {
     test('handles CSS with comments', () => {
       extractClassNamesFromRuleSpy.mockReturnValueOnce(['button']);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         /* This is a comment */
@@ -325,7 +279,6 @@ describe('extractCssClasses', () => {
 
     test('handles CSS with invalid syntax gracefully', () => {
       extractClassNamesFromRuleSpy.mockReturnValue([]);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       // PostCSS should handle this gracefully
       const css = '.incomplete-rule {';
@@ -339,7 +292,6 @@ describe('extractCssClasses', () => {
         const callIndex = extractClassNamesFromRuleSpy.mock.calls.length - 1;
         return mockCalls[callIndex] || [];
       });
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = Array.from(
         { length: 1000 },
@@ -353,8 +305,6 @@ describe('extractCssClasses', () => {
     });
 
     test('handles CSS with no rules but with at-rules', () => {
-      extractComposedClassesSpy.mockReturnValue([]);
-
       const css = `
         @import url('styles.css');
         @charset "UTF-8";
@@ -373,7 +323,6 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['z', 'a'])
         .mockReturnValueOnce(['m', 'b'])
         .mockReturnValueOnce(['x', 'c']);
-      extractComposedClassesSpy.mockReturnValue([]);
 
       const css = `
         .z.a { color: blue; }
@@ -391,8 +340,9 @@ describe('extractCssClasses', () => {
         .mockReturnValueOnce(['primary'])
         .mockReturnValueOnce(['secondary'])
         .mockReturnValueOnce(['large', 'size']);
-      extractComposedClassesSpy.mockReturnValue(['base', 'component']);
 
+      // `base`/`component` are defined locally and composed into others; they
+      // remain in the defined set (issue #83 — they are not stripped out).
       const css = `
         .base.component { padding: 10px; border: 1px solid; }
         .primary { composes: base component; background: blue; }
@@ -401,9 +351,15 @@ describe('extractCssClasses', () => {
       `;
       const result = extractCssClasses(css);
 
-      expect(result).toEqual(['primary', 'secondary', 'large', 'size']);
+      expect(result).toEqual([
+        'base',
+        'component',
+        'primary',
+        'secondary',
+        'large',
+        'size',
+      ]);
       expect(extractClassNamesFromRuleSpy).toHaveBeenCalledTimes(4);
-      expect(extractComposedClassesSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
@@ -4,7 +4,6 @@ import {
   extractClassNamesFromAtRule,
   extractClassNamesFromRule,
 } from './utils/extractClassNamesFromRule.js';
-import { extractComposedClasses } from './utils/extractComposedClasses.js';
 import { isSelectorBearingAtRule } from './utils/isSelectorBearingAtRule.js';
 
 export type CssClassInfo = {
@@ -52,11 +51,6 @@ export const extractCssClasses = (cssContent: string): string[] => {
       classNames.add(className);
     }
   });
-
-  const composedClasses = extractComposedClasses(root);
-  for (const composedClassName of composedClasses) {
-    classNames.delete(composedClassName);
-  }
 
   return Array.from(classNames);
 };
@@ -116,11 +110,6 @@ export const extractCssClassesWithLocations = (
       }
     }
   });
-
-  const composedClasses = extractComposedClasses(root);
-  for (const composedClassName of composedClasses) {
-    classInfoMap.delete(composedClassName);
-  }
 
   return Array.from(classInfoMap.values());
 };

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/index.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/index.ts
@@ -7,3 +7,4 @@ export {
   extractCssClasses,
   extractCssClassesWithLocations,
 } from './extractCssClasses.js';
+export { extractComposedClassesFromContent } from './utils/extractComposedClasses.js';

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractComposedClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractComposedClasses.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import postcss from 'postcss';
-import { extractComposedClasses } from './extractComposedClasses.js';
+import {
+  extractComposedClasses,
+  extractComposedClassesFromContent,
+} from './extractComposedClasses.js';
 
 const createPostCSSRoot = (css: string): postcss.Root => postcss.parse(css);
 
@@ -380,6 +383,80 @@ describe('extractComposedClasses', () => {
         'base-component_v2',
         'modifier--active',
       ]);
+    });
+  });
+
+  describe('should exclude external composes targets (from clause)', () => {
+    test('ignores a target composed from another module', () => {
+      const css = `
+        .card {
+          composes: base from './shared.module.css';
+        }
+      `;
+      const root = createPostCSSRoot(css);
+      expect(extractComposedClasses(root)).toEqual([]);
+    });
+
+    test('ignores a target composed from global', () => {
+      const css = `
+        .card {
+          composes: highlight from global;
+        }
+      `;
+      const root = createPostCSSRoot(css);
+      expect(extractComposedClasses(root)).toEqual([]);
+    });
+
+    test('a from clause excludes every preceding target in that declaration', () => {
+      const css = `
+        .card {
+          composes: a b from './shared.module.css';
+        }
+      `;
+      const root = createPostCSSRoot(css);
+      expect(extractComposedClasses(root)).toEqual([]);
+    });
+
+    test('keeps local targets while excluding external ones across declarations', () => {
+      const css = `
+        .card {
+          composes: localBase;
+          composes: external from './shared.module.css';
+        }
+      `;
+      const root = createPostCSSRoot(css);
+      expect(extractComposedClasses(root)).toEqual(['localBase']);
+    });
+
+    test('a class literally named "from-…" stays local (from is a token, not a substring)', () => {
+      const css = `
+        .card {
+          composes: fromLeft transform;
+        }
+      `;
+      const root = createPostCSSRoot(css);
+      expect(extractComposedClasses(root)).toEqual(['fromLeft', 'transform']);
+    });
+  });
+
+  describe('extractComposedClassesFromContent (content wrapper)', () => {
+    test('parses raw CSS text and returns local composed targets', () => {
+      const css = `
+        .button {
+          composes: base;
+        }
+      `;
+      expect(extractComposedClassesFromContent(css)).toEqual(['base']);
+    });
+
+    test('tolerates SCSS syntax', () => {
+      const css = `
+        .button {
+          composes: base;
+          &:hover { color: red; }
+        }
+      `;
+      expect(extractComposedClassesFromContent(css)).toEqual(['base']);
     });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractComposedClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractComposedClasses.ts
@@ -1,18 +1,45 @@
 import type postcss from 'postcss';
+import postcssScss from 'postcss-scss';
 
+const splitTokens = (value: string): string[] =>
+  value
+    .split(/\s+/)
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+/**
+ * Returns the class names referenced via `composes:` that are defined in the
+ * SAME file. Composing a class is a use of it, so these targets count as used
+ * — but they still exist locally, so they are NOT dropped from the defined set.
+ *
+ * Only same-file targets are returned. `composes: x from '…'` and
+ * `composes: x from global` reference another module, so they are skipped.
+ */
 export const extractComposedClasses = (root: postcss.Root): string[] => {
-  const composedClasses = new Set<string>();
+  const localComposedClasses = new Set<string>();
 
   root.walkDecls('composes', (decl) => {
-    const classNames = decl.value
-      .split(/\s+/)
-      .map((name) => name.trim())
-      .filter((name) => name.length > 0);
+    const tokens = splitTokens(decl.value);
 
-    for (const className of classNames) {
-      composedClasses.add(className);
+    // A `from` token (`composes: a b from <source>`) makes the whole
+    // declaration reference another module, so it adds no local class. Checked
+    // as a token, not a substring, so a class named `from-…` stays local.
+    if (tokens.includes('from')) {
+      return;
+    }
+
+    for (const className of tokens) {
+      localComposedClasses.add(className);
     }
   });
 
-  return Array.from(composedClasses);
+  return Array.from(localComposedClasses);
 };
+
+/**
+ * Same as {@link extractComposedClasses} but takes raw CSS text, so callers
+ * that only hold the file contents don't have to parse it themselves.
+ */
+export const extractComposedClassesFromContent = (
+  cssContent: string
+): string[] => extractComposedClasses(postcssScss.parse(cssContent));


### PR DESCRIPTION
Fixes #83.

A class defined in the same file and referenced via `composes: localClass` was dropped from the defined set, so reading `styles.localClass` was wrongly reported as "used but non-existent". Local composed targets are now kept as defined and counted as used; `composes: x from '…'` / `from global` stay external.

🤖 Generated with [Claude Code](https://claude.com/claude-code)