### PR TITLE
fix: recognize classes in nested selectors starting with a combinator

### DIFF
--- a/.changeset/fix-leading-combinator-nesting.md
+++ b/.changeset/fix-leading-combinator-nesting.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Fix a false "non-existent" report for a class defined in a nested selector that starts with a combinator (#86). A nested SCSS/CSS rule whose selector begins with `>`, `+`, or `~` (e.g. `.wrapper { > .item { … } }`, or `& > .item` once the parent `&` is removed) was rejected by the selector parser, so its class was silently dropped from the defined set and reading `styles.item` looked like a missing class. Such leading combinators are now stripped before parsing, so the nested class is recognized.

--- a/src/__tests__/noError/CssCombinatorNesting/CssCombinatorNesting.module.css
+++ b/src/__tests__/noError/CssCombinatorNesting/CssCombinatorNesting.module.css
@@ -1,0 +1,13 @@
+.wrapper {
+  & > .item {
+    color: red;
+  }
+
+  & + .sibling {
+    color: blue;
+  }
+
+  & ~ .general {
+    color: green;
+  }
+}

--- a/src/__tests__/noError/CssCombinatorNesting/CssCombinatorNesting.tsx
+++ b/src/__tests__/noError/CssCombinatorNesting/CssCombinatorNesting.tsx
@@ -1,0 +1,9 @@
+import styles from './CssCombinatorNesting.module.css';
+
+export const CssCombinatorNesting: React.FC = () => (
+  <div className={styles.wrapper}>
+    <span className={styles.item} />
+    <span className={styles.sibling} />
+    <span className={styles.general} />
+  </div>
+);

--- a/src/__tests__/noError/ScssCombinatorNesting/ScssCombinatorNesting.module.scss
+++ b/src/__tests__/noError/ScssCombinatorNesting/ScssCombinatorNesting.module.scss
@@ -1,0 +1,24 @@
+.wrapper {
+  > .item {
+    color: red;
+  }
+
+  + .sibling {
+    color: blue;
+  }
+
+  ~ .general {
+    color: green;
+  }
+
+  & > .ampersandChild {
+    color: orange;
+  }
+}
+
+.list {
+  > .first,
+  + .second {
+    color: red;
+  }
+}

--- a/src/__tests__/noError/ScssCombinatorNesting/ScssCombinatorNesting.tsx
+++ b/src/__tests__/noError/ScssCombinatorNesting/ScssCombinatorNesting.tsx
@@ -1,0 +1,14 @@
+import styles from './ScssCombinatorNesting.module.scss';
+
+export const ScssCombinatorNesting: React.FC = () => (
+  <div className={styles.wrapper}>
+    <span className={styles.item} />
+    <span className={styles.sibling} />
+    <span className={styles.general} />
+    <span className={styles.ampersandChild} />
+    <div className={styles.list}>
+      <span className={styles.first} />
+      <span className={styles.second} />
+    </div>
+  </div>
+);

--- a/src/__tests__/nonExistentClasses.test.ts
+++ b/src/__tests__/nonExistentClasses.test.ts
@@ -81,6 +81,26 @@ describe('Non-existent CSS classes detection', () => {
     expect(result.stdout).toMatch(/No unused CSS classes found/);
   });
 
+  test('does not report false positive non-existent classes for SCSS nested selectors starting with a combinator', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/noError/ScssCombinatorNesting'
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toMatch(/non-existent CSS classes/);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+  });
+
+  test('does not report false positive non-existent classes for native CSS nesting with a combinator', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/noError/CssCombinatorNesting'
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toMatch(/non-existent CSS classes/);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+  });
+
   test('skips non-existent class detection when dynamic usage is present', () => {
     const result = runCheckUnusedCss('src/__tests__/noDynamic/WithDynamic');
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -342,62 +342,62 @@ describe('extractCssClasses (integration, real pipeline)', () => {
     });
   });
 
-  describe('nested selectors starting with a combinator (US5)', () => {
-    test('N20: child combinator (>) at the start of a nested selector', () => {
+  describe('nested selectors starting with a combinator', () => {
+    test('child combinator (>) at the start of a nested selector', () => {
       expect(extractSorted('.wrapper { > .item { color: red; } }')).toEqual(
         sorted(['wrapper', 'item'])
       );
     });
 
-    test('N21: adjacent sibling combinator (+) at the start', () => {
+    test('adjacent sibling combinator (+) at the start', () => {
       expect(extractSorted('.wrapper { + .sibling { color: red; } }')).toEqual(
         sorted(['wrapper', 'sibling'])
       );
     });
 
-    test('N22: general sibling combinator (~) at the start', () => {
+    test('general sibling combinator (~) at the start', () => {
       expect(extractSorted('.wrapper { ~ .general { color: red; } }')).toEqual(
         sorted(['wrapper', 'general'])
       );
     });
 
-    test('N23: combinator with no space before the class', () => {
+    test('combinator with no space before the class', () => {
       expect(extractSorted('.wrapper { >.item { color: red; } }')).toEqual(
         sorted(['wrapper', 'item'])
       );
     });
 
-    test('N24: explicit & before the combinator', () => {
+    test('explicit & before the combinator', () => {
       expect(extractSorted('.wrapper { & > .item { color: red; } }')).toEqual(
         sorted(['wrapper', 'item'])
       );
     });
 
-    test('N25: deep nesting where every level starts with a combinator', () => {
+    test('deep nesting where every level starts with a combinator', () => {
       expect(extractSorted('.a { > .b { > .c { color: red; } } }')).toEqual(
         sorted(['a', 'b', 'c'])
       );
     });
 
-    test('N26: leading combinator followed by a descendant chain', () => {
+    test('leading combinator followed by a descendant chain', () => {
       expect(
         extractSorted('.wrapper { > .item .child { color: red; } }')
       ).toEqual(sorted(['wrapper', 'item', 'child']));
     });
 
-    test('N27: selector list where members start with a combinator', () => {
+    test('selector list where members start with a combinator', () => {
       expect(
         extractSorted('.wrapper { > .item, + .other { color: red; } }')
       ).toEqual(sorted(['wrapper', 'item', 'other']));
     });
 
-    test('N28: compound class after the leading combinator', () => {
+    test('compound class after the leading combinator', () => {
       expect(
         extractSorted('.wrapper { > .item.active { color: red; } }')
       ).toEqual(sorted(['wrapper', 'item', 'active']));
     });
 
-    test('C20 (no regression): combinator in the middle still works', () => {
+    test('no regression: combinator in the middle still works', () => {
       expect(extractSorted('.wrapper > .item { color: red; }')).toEqual(
         sorted(['wrapper', 'item'])
       );

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -341,4 +341,66 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       expect(extractSorted(css)).toEqual(sorted(['upper', 'inMedia']));
     });
   });
+
+  describe('nested selectors starting with a combinator (US5)', () => {
+    test('N20: child combinator (>) at the start of a nested selector', () => {
+      expect(extractSorted('.wrapper { > .item { color: red; } }')).toEqual(
+        sorted(['wrapper', 'item'])
+      );
+    });
+
+    test('N21: adjacent sibling combinator (+) at the start', () => {
+      expect(extractSorted('.wrapper { + .sibling { color: red; } }')).toEqual(
+        sorted(['wrapper', 'sibling'])
+      );
+    });
+
+    test('N22: general sibling combinator (~) at the start', () => {
+      expect(extractSorted('.wrapper { ~ .general { color: red; } }')).toEqual(
+        sorted(['wrapper', 'general'])
+      );
+    });
+
+    test('N23: combinator with no space before the class', () => {
+      expect(extractSorted('.wrapper { >.item { color: red; } }')).toEqual(
+        sorted(['wrapper', 'item'])
+      );
+    });
+
+    test('N24: explicit & before the combinator', () => {
+      expect(extractSorted('.wrapper { & > .item { color: red; } }')).toEqual(
+        sorted(['wrapper', 'item'])
+      );
+    });
+
+    test('N25: deep nesting where every level starts with a combinator', () => {
+      expect(extractSorted('.a { > .b { > .c { color: red; } } }')).toEqual(
+        sorted(['a', 'b', 'c'])
+      );
+    });
+
+    test('N26: leading combinator followed by a descendant chain', () => {
+      expect(
+        extractSorted('.wrapper { > .item .child { color: red; } }')
+      ).toEqual(sorted(['wrapper', 'item', 'child']));
+    });
+
+    test('N27: selector list where members start with a combinator', () => {
+      expect(
+        extractSorted('.wrapper { > .item, + .other { color: red; } }')
+      ).toEqual(sorted(['wrapper', 'item', 'other']));
+    });
+
+    test('N28: compound class after the leading combinator', () => {
+      expect(
+        extractSorted('.wrapper { > .item.active { color: red; } }')
+      ).toEqual(sorted(['wrapper', 'item', 'active']));
+    });
+
+    test('C20 (no regression): combinator in the middle still works', () => {
+      expect(extractSorted('.wrapper > .item { color: red; }')).toEqual(
+        sorted(['wrapper', 'item'])
+      );
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/clearGlobalSelectors.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/clearGlobalSelectors.ts
@@ -1,3 +1,5 @@
+import { stripLeadingCombinators } from './stripLeadingCombinators.js';
+
 const removeGlobalSelectors = (selector: string): string => {
   let result = '';
   let i = 0;
@@ -32,6 +34,11 @@ export const clearGlobalSelectors = (selector: string): string => {
   processed = processed.replace(/&/g, '');
 
   processed = processed.replace(/\s+/g, ' ').trim();
+
+  // Removing `&` can expose a bare leading combinator (`& > .item` -> `> .item`),
+  // and nested rules may already start with one; strip it so the parser accepts
+  // the remaining compound.
+  processed = stripLeadingCombinators(processed);
 
   if (!processed || processed === ' ') {
     return '';

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/clearGlobalSelectors.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/clearGlobalSelectors.ts
@@ -26,7 +26,7 @@ const removeGlobalSelectors = (selector: string): string => {
   return result;
 };
 
-/* Removes :global() selectors and & references since css-selector-parser doesn't support them */
+/* Removes :global() selectors, & references, and leading combinators since css-selector-parser doesn't support them */
 export const clearGlobalSelectors = (selector: string): string => {
   let processed = selector;
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { stripLeadingCombinators } from './stripLeadingCombinators.js';
+
+describe('stripLeadingCombinators', () => {
+  describe('should strip a leading combinator', () => {
+    test('child combinator (>)', () => {
+      expect(stripLeadingCombinators('> .item')).toBe('.item');
+    });
+
+    test('adjacent sibling combinator (+)', () => {
+      expect(stripLeadingCombinators('+ .sibling')).toBe('.sibling');
+    });
+
+    test('general sibling combinator (~)', () => {
+      expect(stripLeadingCombinators('~ .general')).toBe('.general');
+    });
+
+    test('combinator with no space before the class', () => {
+      expect(stripLeadingCombinators('>.item')).toBe('.item');
+    });
+
+    test('strips a leading combinator from each member of a list', () => {
+      expect(stripLeadingCombinators('> .item, + .other')).toBe(
+        '.item, .other'
+      );
+    });
+  });
+
+  describe('should leave non-leading combinators untouched', () => {
+    test('combinator in the middle of a selector', () => {
+      expect(stripLeadingCombinators('.wrapper > .item')).toBe(
+        '.wrapper > .item'
+      );
+    });
+
+    test('plain descendant selector', () => {
+      expect(stripLeadingCombinators('.wrapper .item')).toBe('.wrapper .item');
+    });
+
+    test('single class', () => {
+      expect(stripLeadingCombinators('.item')).toBe('.item');
+    });
+
+    test('member without a leading combinator stays as-is within a list', () => {
+      expect(stripLeadingCombinators('.item, > .other')).toBe('.item, .other');
+    });
+  });
+
+  describe('should handle edge cases', () => {
+    test('empty string', () => {
+      expect(stripLeadingCombinators('')).toBe('');
+    });
+
+    test('combinator with only whitespace after it', () => {
+      expect(stripLeadingCombinators('> ')).toBe('');
+    });
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.test.ts
@@ -44,6 +44,29 @@ describe('stripLeadingCombinators', () => {
     test('member without a leading combinator stays as-is within a list', () => {
       expect(stripLeadingCombinators('.item, > .other')).toBe('.item, .other');
     });
+
+    test('a comma inside a functional pseudo-class is not a member boundary', () => {
+      // The comma in `:not(.x, .y)` lives inside parens, so it is not a
+      // top-level list separator; the member never restarts and nothing inside
+      // is rewritten.
+      expect(stripLeadingCombinators('.item:not(.x, .y)')).toBe(
+        '.item:not(.x, .y)'
+      );
+    });
+
+    test('preserves commas and whitespace inside an attribute value', () => {
+      // A comma inside a quoted attribute value (`rgb(0,0,0)`) must stay
+      // byte-for-byte; the scan only acts on top-level member starts.
+      expect(stripLeadingCombinators('.item[style*="rgb(0,0,0)"]')).toBe(
+        '.item[style*="rgb(0,0,0)"]'
+      );
+    });
+
+    test('strips the leading combinator but keeps a following attribute value intact', () => {
+      expect(stripLeadingCombinators('> .item[data-x="p,q"]')).toBe(
+        '.item[data-x="p,q"]'
+      );
+    });
   });
 
   describe('should handle edge cases', () => {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.ts
@@ -7,18 +7,88 @@
  * silently drop out of extraction.
  *
  * A leading combinator carries no class of its own, so for class extraction it
- * is pure noise: strip it from the start of each comma-separated selector
- * member, leaving the real compound (`.item`) for the parser.
+ * is pure noise: drop the one that begins each top-level selector member,
+ * leaving the real compound (`.item`) for the parser.
  *
- * Splitting on every comma is safe here because a leading combinator can only
- * appear at the very start of a member; a comma inside `:not(...)`/`:has(...)`
- * is rejoined unchanged, so the only members ever rewritten are those that
- * genuinely begin with `>`, `+`, or `~`.
+ * The scan only ever removes a combinator that sits at the start of a member
+ * (string start, or right after a top-level comma). Commas, combinators, and
+ * whitespace inside parens, brackets, or quotes — e.g. `[style*="rgb(0,0,0)"]`
+ * or `:is(.a, .b)` — are left byte-for-byte untouched, so the surrounding
+ * selector text is never rewritten.
  */
-const LEADING_COMBINATOR_REGEX = /^[>+~]\s*/;
+export const stripLeadingCombinators = (selector: string): string => {
+  let result = '';
+  let depth = 0;
+  let quote: '"' | "'" | null = null;
+  // True at the start of the selector and right after every top-level comma:
+  // the only positions where a leading combinator may legitimately appear.
+  let atMemberStart = true;
 
-export const stripLeadingCombinators = (selector: string): string =>
-  selector
-    .split(',')
-    .map((member) => member.trim().replace(LEADING_COMBINATOR_REGEX, ''))
-    .join(', ');
+  for (let i = 0; i < selector.length; i++) {
+    const char = selector[i];
+
+    if (quote) {
+      result += char;
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      result += char;
+      atMemberStart = false;
+      continue;
+    }
+
+    if (char === '(' || char === '[') {
+      depth++;
+      result += char;
+      atMemberStart = false;
+      continue;
+    }
+
+    if (char === ')' || char === ']') {
+      depth--;
+      result += char;
+      atMemberStart = false;
+      continue;
+    }
+
+    if (depth === 0 && char === ',') {
+      result += char;
+      atMemberStart = true;
+      continue;
+    }
+
+    // Leading whitespace before a member's first token is not yet "content".
+    if (atMemberStart && (char === ' ' || char === '\t' || char === '\n')) {
+      result += char;
+      continue;
+    }
+
+    if (
+      atMemberStart &&
+      depth === 0 &&
+      (char === '>' || char === '+' || char === '~')
+    ) {
+      // Drop the combinator and any whitespace it owns; the member start stays
+      // open so the following compound becomes the member's first token.
+      while (
+        i + 1 < selector.length &&
+        (selector[i + 1] === ' ' ||
+          selector[i + 1] === '\t' ||
+          selector[i + 1] === '\n')
+      ) {
+        i++;
+      }
+      continue;
+    }
+
+    result += char;
+    atMemberStart = false;
+  }
+
+  return result;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/stripLeadingCombinators.ts
@@ -1,0 +1,24 @@
+/**
+ * A nested SCSS/CSS-Modules rule may start its selector with a combinator —
+ * `> .item`, `+ .sibling`, `~ .general` — which is shorthand for
+ * `& > .item` etc. Once the parent `&` is gone (see clearGlobalSelectors),
+ * `css-selector-parser` rejects a selector that begins with a bare combinator
+ * ("Expected rule but '>' found"), which would make the whole rule's classes
+ * silently drop out of extraction.
+ *
+ * A leading combinator carries no class of its own, so for class extraction it
+ * is pure noise: strip it from the start of each comma-separated selector
+ * member, leaving the real compound (`.item`) for the parser.
+ *
+ * Splitting on every comma is safe here because a leading combinator can only
+ * appear at the very start of a member; a comma inside `:not(...)`/`:has(...)`
+ * is rejoined unchanged, so the only members ever rewritten are those that
+ * genuinely begin with `>`, `+`, or `~`.
+ */
+const LEADING_COMBINATOR_REGEX = /^[>+~]\s*/;
+
+export const stripLeadingCombinators = (selector: string): string =>
+  selector
+    .split(',')
+    .map((member) => member.trim().replace(LEADING_COMBINATOR_REGEX, ''))
+    .join(', ');


### PR DESCRIPTION
## Problem

Closes #86.

A class defined in a nested selector that starts with a combinator (`>`, `+`, `~`) was reported as non-existent:

```scss
.wrapper {
  > .item { color: red; }
}
```

```
$ check-unused-css src
Found 1 classes used in source files but non-existent in CSS:
  Foo.tsx:3:82 - .item
```

## Root cause

When a nested rule's selector starts with a bare combinator, `css-selector-parser` throws `Expected rule but ">" found`, so `extractClassNamesFromSelector` catches the error and returns `[]` — the rule's classes are silently dropped from the *defined* set. Reading `styles.item` then looks like a missing class.

This also affects native CSS Nesting written as `& > .item`: once `clearGlobalSelectors` strips the leading `&`, the selector becomes `> .item`, which hits the same parser failure.

## Fix

Strip a leading combinator from each comma-separated selector member in `clearGlobalSelectors` (the shared chokepoint feeding the parser), after `&` removal. A leading combinator carries no class of its own, so dropping it leaves the real compound (`.item`) for the parser while non-leading combinators (`.wrapper > .item`) are untouched.

## Tests

- New unit `stripLeadingCombinators.test.ts`.
- New integration cases (`extractCssClasses.integration.test.ts`): `>`, `+`, `~`, no-space, `& >`, deep nesting, descendant chains, selector lists, compound classes, plus a no-regression case for a mid-selector combinator.
- New end-to-end fixtures `ScssCombinatorNesting` (SCSS) and `CssCombinatorNesting` (native CSS) wired into `nonExistentClasses.test.ts`.

## Verification

- Full suite: 922 tests pass; format/lint/type clean.
- Built locally and installed into a real consumer project (`apps/builder`): the fixture `& > .item` was a false positive on the old version and is correctly recognized on this build, with no regressions on the existing stylesheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)