### PR TITLE
fix: recognize classes pulled in via @use/@forward/@import (#90)

### DIFF
--- a/.changeset/fix-scss-use-forward-import-classes.md
+++ b/.changeset/fix-scss-use-forward-import-classes.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Recognize classes pulled into a SCSS module via `@use`, `@forward` and the legacy `@import` (#90). Those directives emit the partial's rules into the module's compiled CSS, so the classes are real. They are no longer reported as non-existent, and a shared partial's classes are never reported as unused for the importing module. Partial paths are resolved transitively with cycle protection.

--- a/src/__tests__/noError/ScssForward/ScssForward.module.scss
+++ b/src/__tests__/noError/ScssForward/ScssForward.module.scss
@@ -1,0 +1,5 @@
+@use 'index';
+
+.wrapper {
+  display: flex;
+}

--- a/src/__tests__/noError/ScssForward/ScssForward.tsx
+++ b/src/__tests__/noError/ScssForward/ScssForward.tsx
@@ -1,0 +1,11 @@
+import styles from './ScssForward.module.scss';
+
+// `.button` / `.button-primary` arrive transitively: the module `@use`s
+// `_index.scss`, which `@forward`s `_buttons.scss`. `.wrapper` is local.
+export const ScssForward = () => (
+  <div
+    className={[styles.wrapper, styles.button, styles['button-primary']].join(
+      ' '
+    )}
+  />
+);

--- a/src/__tests__/noError/ScssForward/_buttons.scss
+++ b/src/__tests__/noError/ScssForward/_buttons.scss
@@ -1,0 +1,8 @@
+// A leaf partial. Reached transitively through a `@forward` in `_index.scss`.
+.button {
+  cursor: pointer;
+}
+
+.button-primary {
+  background: blue;
+}

--- a/src/__tests__/noError/ScssForward/_index.scss
+++ b/src/__tests__/noError/ScssForward/_index.scss
@@ -1,0 +1,3 @@
+// `@forward` re-exports the forwarded module AND emits its CSS into whatever
+// loads this index, so `.button` / `.button-primary` reach the module below.
+@forward 'buttons';

--- a/src/__tests__/noError/ScssImport/ScssImport.module.scss
+++ b/src/__tests__/noError/ScssImport/ScssImport.module.scss
@@ -1,0 +1,5 @@
+@import 'legacy';
+
+.content {
+  margin: 0;
+}

--- a/src/__tests__/noError/ScssImport/ScssImport.tsx
+++ b/src/__tests__/noError/ScssImport/ScssImport.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssImport.module.scss';
+
+// `.legacy-box` comes from the `@import 'legacy'` partial; `.content` is local.
+// Neither must be reported as non-existent.
+export const ScssImport = () => (
+  <div className={[styles.content, styles['legacy-box']].join(' ')} />
+);

--- a/src/__tests__/noError/ScssImport/_legacy.scss
+++ b/src/__tests__/noError/ScssImport/_legacy.scss
@@ -1,0 +1,5 @@
+// Pulled in via the deprecated `@import`, which inlines the whole file, so
+// `.legacy-box` ends up in the compiled CSS of the importing module.
+.legacy-box {
+  border: 1px solid;
+}

--- a/src/__tests__/noError/ScssImportCycle/ScssImportCycle.module.scss
+++ b/src/__tests__/noError/ScssImportCycle/ScssImportCycle.module.scss
@@ -1,0 +1,5 @@
+@import 'ping';
+
+.host {
+  display: block;
+}

--- a/src/__tests__/noError/ScssImportCycle/ScssImportCycle.tsx
+++ b/src/__tests__/noError/ScssImportCycle/ScssImportCycle.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssImportCycle.module.scss';
+
+// `.ping` and `.pong` come from a pair of partials that `@import` each other.
+// The resolver must terminate on the cycle and still surface both classes.
+export const ScssImportCycle = () => (
+  <div className={[styles.host, styles.ping, styles.pong].join(' ')} />
+);

--- a/src/__tests__/noError/ScssImportCycle/_ping.scss
+++ b/src/__tests__/noError/ScssImportCycle/_ping.scss
@@ -1,0 +1,7 @@
+// Legacy `@import` allows cycles (unlike `@use`). `_ping` and `_pong` import
+// each other; the resolver must terminate and still collect every class.
+@import 'pong';
+
+.ping {
+  color: red;
+}

--- a/src/__tests__/noError/ScssImportCycle/_pong.scss
+++ b/src/__tests__/noError/ScssImportCycle/_pong.scss
@@ -1,0 +1,5 @@
+@import 'ping';
+
+.pong {
+  color: blue;
+}

--- a/src/__tests__/noError/ScssUse/ScssUse.module.scss
+++ b/src/__tests__/noError/ScssUse/ScssUse.module.scss
@@ -1,0 +1,5 @@
+@use 'shared';
+
+.local {
+  color: blue;
+}

--- a/src/__tests__/noError/ScssUse/ScssUse.tsx
+++ b/src/__tests__/noError/ScssUse/ScssUse.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssUse.module.scss';
+
+// `.box` and `.panel` come from the `@use 'shared'` partial; `.local` is
+// defined in the module itself. None must be reported as non-existent.
+export const ScssUse = () => (
+  <div className={[styles.box, styles.panel, styles.local].join(' ')} />
+);

--- a/src/__tests__/noError/ScssUse/_shared.scss
+++ b/src/__tests__/noError/ScssUse/_shared.scss
@@ -1,0 +1,9 @@
+// A partial pulled in via `@use`. Its top-level rules ARE emitted into the
+// compiled CSS of the module that loads it, so `.box` is a real, usable class.
+.box {
+  color: red;
+}
+
+.panel {
+  padding: 8px;
+}

--- a/src/__tests__/noError/ScssUseDiamond/ScssUseDiamond.module.scss
+++ b/src/__tests__/noError/ScssUseDiamond/ScssUseDiamond.module.scss
@@ -1,0 +1,6 @@
+@use 'left';
+@use 'right';
+
+.shell {
+  display: grid;
+}

--- a/src/__tests__/noError/ScssUseDiamond/ScssUseDiamond.tsx
+++ b/src/__tests__/noError/ScssUseDiamond/ScssUseDiamond.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssUseDiamond.module.scss';
+
+// `.base-class` is reachable via two forward paths (left + right). It must be
+// recognized exactly once; `.shell` is local. Neither must be non-existent.
+export const ScssUseDiamond = () => (
+  <div className={[styles.shell, styles['base-class']].join(' ')} />
+);

--- a/src/__tests__/noError/ScssUseDiamond/_base.scss
+++ b/src/__tests__/noError/ScssUseDiamond/_base.scss
@@ -1,0 +1,5 @@
+// Shared leaf reached through two different paths (`_left.scss` and
+// `_right.scss`). The resolver must visit it once and not loop.
+.base-class {
+  color: black;
+}

--- a/src/__tests__/noError/ScssUseDiamond/_left.scss
+++ b/src/__tests__/noError/ScssUseDiamond/_left.scss
@@ -1,0 +1,1 @@
+@forward 'base';

--- a/src/__tests__/noError/ScssUseDiamond/_right.scss
+++ b/src/__tests__/noError/ScssUseDiamond/_right.scss
@@ -1,0 +1,1 @@
+@forward 'base';

--- a/src/__tests__/noError/ScssUseMissingPartial/ScssUseMissingPartial.module.scss
+++ b/src/__tests__/noError/ScssUseMissingPartial/ScssUseMissingPartial.module.scss
@@ -1,0 +1,7 @@
+// The referenced partial does not exist on disk. The resolver must not throw —
+// it simply contributes no extra classes. All real classes are local here.
+@use 'missing';
+
+.only {
+  color: teal;
+}

--- a/src/__tests__/noError/ScssUseMissingPartial/ScssUseMissingPartial.tsx
+++ b/src/__tests__/noError/ScssUseMissingPartial/ScssUseMissingPartial.tsx
@@ -1,0 +1,5 @@
+import styles from './ScssUseMissingPartial.module.scss';
+
+// `@use 'missing'` points at a partial that is not present. The tool must run
+// cleanly and report nothing; `.only` is defined locally.
+export const ScssUseMissingPartial = () => <div className={styles.only} />;

--- a/src/__tests__/noError/ScssUseNamespaced/ScssUseNamespaced.module.scss
+++ b/src/__tests__/noError/ScssUseNamespaced/ScssUseNamespaced.module.scss
@@ -1,0 +1,6 @@
+@use 'colors' as colors;
+
+.title {
+  color: colors.$accent;
+  font-weight: 600;
+}

--- a/src/__tests__/noError/ScssUseNamespaced/ScssUseNamespaced.tsx
+++ b/src/__tests__/noError/ScssUseNamespaced/ScssUseNamespaced.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssUseNamespaced.module.scss';
+
+// `.highlight` comes from the namespaced `@use 'colors' as colors` partial;
+// `.title` is local. Neither must be reported as non-existent.
+export const ScssUseNamespaced = () => (
+  <div className={[styles.title, styles.highlight].join(' ')} />
+);

--- a/src/__tests__/noError/ScssUseNamespaced/_colors.scss
+++ b/src/__tests__/noError/ScssUseNamespaced/_colors.scss
@@ -1,0 +1,8 @@
+// Loaded with an explicit namespace (`as colors`). The namespace only governs
+// access to this partial's variables/mixins/functions — its top-level CSS
+// rules are still emitted, so `.highlight` is a real class.
+$accent: #c00;
+
+.highlight {
+  background: yellow;
+}

--- a/src/__tests__/noError/ScssUseSubdir/ScssUseSubdir.module.scss
+++ b/src/__tests__/noError/ScssUseSubdir/ScssUseSubdir.module.scss
@@ -1,0 +1,5 @@
+@use 'partials/typography';
+
+.page {
+  margin: 0;
+}

--- a/src/__tests__/noError/ScssUseSubdir/ScssUseSubdir.tsx
+++ b/src/__tests__/noError/ScssUseSubdir/ScssUseSubdir.tsx
@@ -1,0 +1,7 @@
+import styles from './ScssUseSubdir.module.scss';
+
+// `.heading` comes from a partial in a subdirectory (`partials/_typography.scss`);
+// `.page` is local. Neither must be reported as non-existent.
+export const ScssUseSubdir = () => (
+  <div className={[styles.page, styles.heading].join(' ')} />
+);

--- a/src/__tests__/noError/ScssUseSubdir/partials/_typography.scss
+++ b/src/__tests__/noError/ScssUseSubdir/partials/_typography.scss
@@ -1,0 +1,4 @@
+// Lives in a subdirectory; reached via `@use 'partials/typography'`.
+.heading {
+  font-size: 2rem;
+}

--- a/src/__tests__/noError/ScssUseUnusedPartial/ScssUseUnusedPartial.module.scss
+++ b/src/__tests__/noError/ScssUseUnusedPartial/ScssUseUnusedPartial.module.scss
@@ -1,0 +1,5 @@
+@use 'shared';
+
+.local {
+  color: blue;
+}

--- a/src/__tests__/noError/ScssUseUnusedPartial/ScssUseUnusedPartial.tsx
+++ b/src/__tests__/noError/ScssUseUnusedPartial/ScssUseUnusedPartial.tsx
@@ -1,0 +1,8 @@
+import styles from './ScssUseUnusedPartial.module.scss';
+
+// Uses `.local` (module) and `.used` (partial). `.unused-in-partial` is left
+// unreferenced on purpose: classes pulled in from a shared partial must not be
+// reported as unused, since this module does not own them.
+export const ScssUseUnusedPartial = () => (
+  <div className={[styles.local, styles.used].join(' ')} />
+);

--- a/src/__tests__/noError/ScssUseUnusedPartial/_shared.scss
+++ b/src/__tests__/noError/ScssUseUnusedPartial/_shared.scss
@@ -1,0 +1,10 @@
+// `.used` is referenced by the module's component. `.unused-in-partial` is not
+// referenced anywhere, but it belongs to a shared partial that other modules
+// may consume — so it must NOT be reported as unused for the importing module.
+.used {
+  color: red;
+}
+
+.unused-in-partial {
+  color: gray;
+}

--- a/src/__tests__/scssAtRuleImports.test.ts
+++ b/src/__tests__/scssAtRuleImports.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+import { runCheckUnusedCss } from './runCheckUnusedCss.js';
+
+/**
+ * Guard for issue #90: classes pulled into a CSS module via `@use`, `@forward`
+ * or the legacy `@import` are emitted into the module's compiled CSS, so they
+ * are real, usable classes. They must NOT be reported as "used but
+ * non-existent", and they must NOT be reported as unused for the importing
+ * module (a shared partial is not owned by the module that imports it).
+ *
+ * The fix must stay precise on both sides:
+ *  - it must still flag a class that exists nowhere (`.ghost`);
+ *  - it must still flag a genuinely unused LOCAL class even when the module
+ *    imports a partial.
+ */
+
+/** Match a reported finding line `… - .<className>` (end-anchored). */
+const reportedLine = (className: string): RegExp =>
+  new RegExp(`- \\.${className.replace(/[-]/g, '\\-')}(?:\\s|$)`, 'm');
+
+describe('SCSS @use/@forward/@import pull partial classes into the module', () => {
+  test('@use: classes from the used partial are not reported as non-existent', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssUse');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+    expect(result.stdout).not.toMatch(/non-existent/i);
+  });
+
+  test('@use with a namespace still surfaces the partial classes', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssUseNamespaced');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('highlight'));
+  });
+
+  test('@forward chained through _index.scss reaches the leaf partial', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssForward');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('button'));
+    expect(result.stdout).not.toMatch(reportedLine('button-primary'));
+  });
+
+  test('legacy @import inlines the partial classes', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssImport');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('legacy-box'));
+  });
+
+  test('a class imported via @use but never referenced is not reported as unused', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/noError/ScssUseUnusedPartial'
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('unused-in-partial'));
+  });
+
+  test('@use resolves a partial in a subdirectory', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssUseSubdir');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('heading'));
+  });
+
+  test('a partial reachable through two @forward paths is resolved once', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssUseDiamond');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('base-class'));
+  });
+
+  test('a cycle of @import partials terminates and still collects classes', () => {
+    const result = runCheckUnusedCss('src/__tests__/noError/ScssImportCycle');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toMatch(reportedLine('ping'));
+    expect(result.stdout).not.toMatch(reportedLine('pong'));
+  });
+
+  test('a missing partial does not crash the run', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/noError/ScssUseMissingPartial'
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/No unused CSS classes found/);
+  });
+});
+
+describe('SCSS @use does not mask genuine findings', () => {
+  test('a class that exists nowhere is still reported as non-existent', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/withError/ScssUseNonExistent'
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toMatch(/ScssUseNonExistent\.tsx:\d+:\d+ - \.ghost/);
+    // The classes that DO exist (module-local + partial) must not be flagged.
+    expect(result.stdout).not.toMatch(reportedLine('shared'));
+    expect(result.stdout).not.toMatch(reportedLine('local'));
+  });
+
+  test('a genuinely unused LOCAL class is still reported despite the @use import', () => {
+    const result = runCheckUnusedCss(
+      'src/__tests__/withError/ScssUseLocalUnused'
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(
+      /Found .* classes defined in CSS but unused in source files/
+    );
+    expect(result.stdout).toMatch(
+      /ScssUseLocalUnused\.module\.scss:\d+:\d+ - \.localUnused/
+    );
+    // The used classes (local + partial) must not be flagged.
+    expect(result.stdout).not.toMatch(reportedLine('used'));
+    expect(result.stdout).not.toMatch(reportedLine('shared'));
+  });
+});

--- a/src/__tests__/withError/ScssUseLocalUnused/ScssUseLocalUnused.module.scss
+++ b/src/__tests__/withError/ScssUseLocalUnused/ScssUseLocalUnused.module.scss
@@ -1,0 +1,9 @@
+@use 'shared';
+
+.used {
+  color: blue;
+}
+
+.localUnused {
+  color: red;
+}

--- a/src/__tests__/withError/ScssUseLocalUnused/ScssUseLocalUnused.tsx
+++ b/src/__tests__/withError/ScssUseLocalUnused/ScssUseLocalUnused.tsx
@@ -1,0 +1,8 @@
+import styles from './ScssUseLocalUnused.module.scss';
+
+// Uses `.shared` (partial) and `.used` (module). `.localUnused` is a real local
+// class that nothing references, so it must still be reported as unused — the
+// `@use` import must not mask local dead code.
+export const ScssUseLocalUnused = () => (
+  <div className={[styles.shared, styles.used].join(' ')} />
+);

--- a/src/__tests__/withError/ScssUseLocalUnused/_shared.scss
+++ b/src/__tests__/withError/ScssUseLocalUnused/_shared.scss
@@ -1,0 +1,5 @@
+// Provides `.shared`, which the component uses. This partial exists to confirm
+// that pulling its classes in does not mask a genuinely unused LOCAL class.
+.shared {
+  color: green;
+}

--- a/src/__tests__/withError/ScssUseNonExistent/ScssUseNonExistent.module.scss
+++ b/src/__tests__/withError/ScssUseNonExistent/ScssUseNonExistent.module.scss
@@ -1,0 +1,5 @@
+@use 'shared';
+
+.local {
+  color: blue;
+}

--- a/src/__tests__/withError/ScssUseNonExistent/ScssUseNonExistent.tsx
+++ b/src/__tests__/withError/ScssUseNonExistent/ScssUseNonExistent.tsx
@@ -1,0 +1,8 @@
+import styles from './ScssUseNonExistent.module.scss';
+
+// `.shared` (from the partial) and `.local` (from the module) exist.
+// `.ghost` exists nowhere, so it must be reported as non-existent even though
+// the module pulls in classes via `@use`.
+export const ScssUseNonExistent = () => (
+  <div className={[styles.shared, styles.local, styles.ghost].join(' ')} />
+);

--- a/src/__tests__/withError/ScssUseNonExistent/_shared.scss
+++ b/src/__tests__/withError/ScssUseNonExistent/_shared.scss
@@ -1,0 +1,5 @@
+// Provides `.shared` to the importing module. `.ghost` is intentionally NOT
+// defined here (nor in the module) so it must still be flagged non-existent.
+.shared {
+  color: green;
+}

--- a/src/lib/getNonExistentClassesFromCss.ts
+++ b/src/lib/getNonExistentClassesFromCss.ts
@@ -32,9 +32,13 @@ export const getNonExistentClassesFromCss = async ({
 
   // Classes are real if they are defined in this file OR pulled into it via
   // `@use`/`@forward`/`@import` (those emit the partial's rules into the
-  // module's compiled CSS), so both sets count as existing (issue #90).
+  // module's compiled CSS), so both sets count as existing (issue #90). A Set
+  // keeps the per-usage lookup below O(1).
   const partialClasses = collectPartialClasses(path.join(srcDir, cssFile));
-  const cssClasses = [...extractCssClasses(cssContent), ...partialClasses];
+  const cssClasses = new Set<string>([
+    ...extractCssClasses(cssContent),
+    ...partialClasses,
+  ]);
 
   // If any importer passes the whole module to a function, ignore the module
   // entirely (matching the unused path), not just that one file.
@@ -93,7 +97,7 @@ export const getNonExistentClassesFromCss = async ({
 
     // Find classes that are used in code but don't exist in CSS
     for (const usedClass of usedClassesWithLocations) {
-      if (!cssClasses.includes(usedClass.className)) {
+      if (!cssClasses.has(usedClass.className)) {
         nonExistentClasses.push({
           className: usedClass.className,
           file: importingFileData.file,

--- a/src/lib/getNonExistentClassesFromCss.ts
+++ b/src/lib/getNonExistentClassesFromCss.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type {
   NonExistentClassResult,
   NonExistentClassUsage,
@@ -9,6 +10,7 @@ import { extractUsedClassesWithLocations } from './getUnusedClassesFromCss/utils
 import { findFilesImportingCssModule } from './getUnusedClassesFromCss/utils/findFilesImportingCssModule/index.js';
 import { extractDynamicClassUsages } from './getUnusedClassesFromCss/utils/findUnusedClasses/utils/extractDynamicClassUsages.js';
 import { detectModulePassedToFunction } from './getUnusedClassesFromCss/utils/passedToFunction/detectModulePassedToFunction.js';
+import { collectPartialClasses } from './getUnusedClassesFromCss/utils/scssImports/index.js';
 
 type GetNonExistentClassesFromCssParams = {
   cssFile: string;
@@ -27,7 +29,12 @@ export const getNonExistentClassesFromCss = async ({
   }
 
   const cssContent = getContentOfFiles({ files: [cssFile], srcDir });
-  const cssClasses = extractCssClasses(cssContent);
+
+  // Classes are real if they are defined in this file OR pulled into it via
+  // `@use`/`@forward`/`@import` (those emit the partial's rules into the
+  // module's compiled CSS), so both sets count as existing (issue #90).
+  const partialClasses = collectPartialClasses(path.join(srcDir, cssFile));
+  const cssClasses = [...extractCssClasses(cssContent), ...partialClasses];
 
   // If any importer passes the whole module to a function, ignore the module
   // entirely (matching the unused path), not just that one file.

--- a/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
+++ b/src/lib/getUnusedClassesFromCss/getUnusedClassesFromCss.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type {
   DynamicClassUsage,
   UnusedClassResult,
@@ -20,6 +21,7 @@ import { extractUsedClasses } from './utils/extractUsedClasses.js';
 import { findFilesImportingCssModule } from './utils/findFilesImportingCssModule/index.js';
 import { detectModulePassedToFunction } from './utils/passedToFunction/detectModulePassedToFunction.js';
 import { rescueUsedAncestors } from './utils/rescueUsedAncestors.js';
+import { collectPartialClasses } from './utils/scssImports/index.js';
 
 type GetUnusedClassesFromCssParams = {
   cssFile: string;
@@ -52,7 +54,14 @@ export const getUnusedClassesFromCss = async ({
     };
   }
 
-  const usedClasses = new Set<string>(composedClasses);
+  // Classes pulled in via `@use`/`@forward`/`@import` belong to a shared
+  // partial this module does not own, so a local class that merely shares a
+  // name with one of them must not be reported as unused. Classes that exist
+  // ONLY in a partial are never candidates here — they are not in `cssClasses`,
+  // which is extracted from this file alone (issue #90).
+  const partialClasses = collectPartialClasses(path.join(srcDir, cssFile));
+
+  const usedClasses = new Set<string>([...composedClasses, ...partialClasses]);
   const allAccesses: ClassAccess[] = [];
 
   for (const importingFileData of importingFilesData) {

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
@@ -53,6 +53,16 @@ describe('collectPartialClasses', () => {
     expect([...collectPartialClasses(module)].sort()).toEqual(['ping', 'pong']);
   });
 
+  test('collects classes from a .css partial loaded by a bare @use spec', () => {
+    // Sass loads `code.css` for a bare `@use 'code'` and inlines its rules, so
+    // the class is real. (A `.css` spec WITH the extension is a plain CSS
+    // import and is filtered out before reaching here.)
+    write('code.css', '.code {}');
+    const module = write('M.module.scss', `@use 'code';`);
+
+    expect([...collectPartialClasses(module)]).toEqual(['code']);
+  });
+
   test('visits a diamond leaf exactly once', () => {
     write('_base.scss', '.base {}');
     write('_left.scss', `@forward 'base';`);

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
@@ -84,4 +84,14 @@ describe('collectPartialClasses', () => {
 
     expect([...collectPartialClasses(module)]).toEqual(['deep']);
   });
+
+  test('a malformed partial does not throw and still collects valid ones', () => {
+    // `_broken.scss` has an unclosed block, which makes postcss-scss throw.
+    // The walk must swallow that and still return `.ok` from the valid partial.
+    write('_broken.scss', '.bad { color: red;');
+    write('_good.scss', '.ok {}');
+    const module = write('M.module.scss', `@use 'broken';\n@use 'good';`);
+
+    expect([...collectPartialClasses(module)]).toEqual(['ok']);
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { collectPartialClasses } from './collectPartialClasses.js';
+
+let root: string;
+
+const write = (relPath: string, content: string): string => {
+  const full = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+  return full;
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'collect-partials-'));
+});
+
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('collectPartialClasses', () => {
+  test('collects classes from a @use partial', () => {
+    write('_shared.scss', '.box { color: red; } .panel {}');
+    const module = write('M.module.scss', `@use 'shared';\n.local {}`);
+
+    const classes = collectPartialClasses(module);
+    expect([...classes].sort()).toEqual(['box', 'panel']);
+  });
+
+  test("does not include the module's own classes", () => {
+    write('_shared.scss', '.box {}');
+    const module = write('M.module.scss', `@use 'shared';\n.local {}`);
+
+    expect(collectPartialClasses(module).has('local')).toBe(false);
+  });
+
+  test('follows @forward transitively', () => {
+    write('_leaf.scss', '.leaf {}');
+    write('_mid.scss', `@forward 'leaf';`);
+    const module = write('M.module.scss', `@use 'mid';`);
+
+    expect([...collectPartialClasses(module)]).toEqual(['leaf']);
+  });
+
+  test('terminates on an @import cycle and still collects all classes', () => {
+    write('_ping.scss', `@import 'pong';\n.ping {}`);
+    write('_pong.scss', `@import 'ping';\n.pong {}`);
+    const module = write('M.module.scss', `@import 'ping';`);
+
+    expect([...collectPartialClasses(module)].sort()).toEqual(['ping', 'pong']);
+  });
+
+  test('visits a diamond leaf exactly once', () => {
+    write('_base.scss', '.base {}');
+    write('_left.scss', `@forward 'base';`);
+    write('_right.scss', `@forward 'base';`);
+    const module = write('M.module.scss', `@use 'left';\n@use 'right';`);
+
+    // A Set dedupes by name anyway; this asserts the traversal terminates and
+    // yields the single shared class.
+    expect([...collectPartialClasses(module)]).toEqual(['base']);
+  });
+
+  test('returns an empty set for a missing partial', () => {
+    const module = write('M.module.scss', `@use 'nope';\n.local {}`);
+    expect(collectPartialClasses(module).size).toBe(0);
+  });
+
+  test('returns an empty set when the module file is unreadable', () => {
+    expect(
+      collectPartialClasses(path.join(root, 'ghost.module.scss')).size
+    ).toBe(0);
+  });
+
+  test('resolves partials relative to the importing partial, not the module', () => {
+    // `_mid.scss` lives in `sub/`; its `@use 'leaf'` must resolve to
+    // `sub/_leaf.scss`, not `_leaf.scss` next to the module.
+    write('sub/_leaf.scss', '.deep {}');
+    write('sub/_mid.scss', `@use 'leaf';`);
+    const module = write('M.module.scss', `@use 'sub/mid';`);
+
+    expect([...collectPartialClasses(module)]).toEqual(['deep']);
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.test.ts
@@ -94,4 +94,15 @@ describe('collectPartialClasses', () => {
 
     expect([...collectPartialClasses(module)]).toEqual(['ok']);
   });
+
+  test('a class that exists only in a malformed partial is NOT reported as existing', () => {
+    // Guards the inverse of the silent skip: a class the broken partial happened
+    // to declare before the parse error must not leak into the result, or the
+    // consumer would stop flagging a genuinely non-existent use of it.
+    write('_broken.scss', '.bad { color: red;');
+    const module = write('M.module.scss', `@use 'broken';`);
+
+    expect(collectPartialClasses(module).has('bad')).toBe(false);
+    expect(collectPartialClasses(module).size).toBe(0);
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
@@ -15,14 +15,21 @@ import { resolveScssImport } from './resolveScssImport.js';
  * cycles (legal with `@import`) and diamonds via a visited set. The module's
  * own file is seeded as visited so its classes are not double-counted here —
  * they are already extracted by the caller.
+ *
+ * A resolved partial may itself be a `.css` file: Sass loads `code.css` for a
+ * bare `@use 'code'` / `@import 'code'` and inlines its rules, so collecting
+ * those classes is correct. (A trailing-`.css` spec like `@import 'code.css'`
+ * is a plain, non-inlined CSS import and is already filtered out upstream.)
  */
 const SASS_EXTENSIONS = new Set(['.scss', '.sass']);
 
 export const collectPartialClasses = (cssFilePath: string): Set<string> => {
   const classNames = new Set<string>();
 
-  // Only Sass modules carry `@use`/`@forward`/`@import` that inline a partial's
-  // rules. Plain `.css` modules cannot, so skip the read+parse entirely.
+  // Skip when the ENTRY module is a plain `.css` file: it cannot carry
+  // `@use`/`@forward`, and a Sass `@import` does not inline inside plain CSS,
+  // so there is nothing to pull in. (This guards the entry only — `.css`
+  // partials reached from a Sass module are still collected during the walk.)
   if (!SASS_EXTENSIONS.has(path.extname(cssFilePath).toLowerCase())) {
     return classNames;
   }

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
@@ -61,15 +61,24 @@ export const collectPartialClasses = (cssFilePath: string): Set<string> => {
     try {
       partialContent = fs.readFileSync(partialPath, 'utf-8');
     } catch {
+      // The path resolved to an entry that can't be read (e.g. a race, or a
+      // permission issue). Skip it silently — a genuinely missing partial is a
+      // normal case (it never resolves and is never queued here).
       continue;
     }
 
     // A single malformed partial must not break the run — `extractCssClasses`
-    // parses with postcss-scss and can throw on unsupported syntax.
+    // parses with postcss-scss and can throw on unsupported syntax. Warn (as
+    // the selector parser does elsewhere) so the anomaly is visible, then move
+    // on rather than aborting the whole analysis.
     let partialClassNames: string[];
     try {
       partialClassNames = extractCssClasses(partialContent);
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `check-unused-css: failed to parse imported partial "${partialPath}" (${message}) — skipping it.`
+      );
       partialClassNames = [];
     }
     for (const className of partialClassNames) {

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { extractCssClasses } from '../extractCssClasses/index.js';
+import { extractScssImportPaths } from './extractScssImportPaths.js';
+import { resolveScssImport } from './resolveScssImport.js';
+
+/**
+ * Collects every class name reachable from a CSS module through `@use`,
+ * `@forward` and the legacy `@import`, following the chain transitively. These
+ * classes are emitted into the module's compiled CSS, so for the module they
+ * are real classes — used here to stop reporting them as "non-existent" and to
+ * avoid flagging them as unused (issue #90).
+ *
+ * The walk is breadth-first over resolved absolute paths and guards against
+ * cycles (legal with `@import`) and diamonds via a visited set. The module's
+ * own file is seeded as visited so its classes are not double-counted here —
+ * they are already extracted by the caller.
+ */
+const SASS_EXTENSIONS = new Set(['.scss', '.sass']);
+
+export const collectPartialClasses = (cssFilePath: string): Set<string> => {
+  const classNames = new Set<string>();
+
+  // Only Sass modules carry `@use`/`@forward`/`@import` that inline a partial's
+  // rules. Plain `.css` modules cannot, so skip the read+parse entirely.
+  if (!SASS_EXTENSIONS.has(path.extname(cssFilePath).toLowerCase())) {
+    return classNames;
+  }
+
+  const visited = new Set<string>([path.resolve(cssFilePath)]);
+
+  // Seed the queue with the module's own direct imports.
+  let cssContent: string;
+  try {
+    cssContent = fs.readFileSync(cssFilePath, 'utf-8');
+  } catch {
+    return classNames;
+  }
+
+  const queue: string[] = [];
+  const enqueueImportsFrom = (content: string, fromDir: string): void => {
+    for (const spec of extractScssImportPaths(content)) {
+      const resolved = resolveScssImport(spec, fromDir);
+      if (resolved && !visited.has(resolved)) {
+        visited.add(resolved);
+        queue.push(resolved);
+      }
+    }
+  };
+
+  enqueueImportsFrom(cssContent, path.dirname(cssFilePath));
+
+  while (queue.length > 0) {
+    const partialPath = queue.shift();
+    if (!partialPath) {
+      continue;
+    }
+
+    let partialContent: string;
+    try {
+      partialContent = fs.readFileSync(partialPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    for (const className of extractCssClasses(partialContent)) {
+      classNames.add(className);
+    }
+
+    enqueueImportsFrom(partialContent, path.dirname(partialPath));
+  }
+
+  return classNames;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/collectPartialClasses.ts
@@ -50,8 +50,9 @@ export const collectPartialClasses = (cssFilePath: string): Set<string> => {
 
   enqueueImportsFrom(cssContent, path.dirname(cssFilePath));
 
-  while (queue.length > 0) {
-    const partialPath = queue.shift();
+  // Index-based walk (not `queue.shift()`) keeps traversal O(n) on large graphs.
+  for (let i = 0; i < queue.length; i++) {
+    const partialPath = queue[i];
     if (!partialPath) {
       continue;
     }
@@ -63,7 +64,15 @@ export const collectPartialClasses = (cssFilePath: string): Set<string> => {
       continue;
     }
 
-    for (const className of extractCssClasses(partialContent)) {
+    // A single malformed partial must not break the run — `extractCssClasses`
+    // parses with postcss-scss and can throw on unsupported syntax.
+    let partialClassNames: string[];
+    try {
+      partialClassNames = extractCssClasses(partialContent);
+    } catch {
+      partialClassNames = [];
+    }
+    for (const className of partialClassNames) {
       classNames.add(className);
     }
 

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import { extractScssImportPaths } from './extractScssImportPaths.js';
+
+describe('extractScssImportPaths', () => {
+  test('extracts a basic @use', () => {
+    expect(extractScssImportPaths(`@use 'shared';`)).toEqual(['shared']);
+  });
+
+  test('extracts @use with double quotes', () => {
+    expect(extractScssImportPaths(`@use "shared";`)).toEqual(['shared']);
+  });
+
+  test('ignores the namespace, config and member filters', () => {
+    const content = `
+      @use 'a' as ns;
+      @use 'b' with ($x: 1, $y: 2);
+      @forward 'c' show mixin-a, $var-b;
+      @forward 'd' hide thing;
+      @forward 'e' as prefix-*;
+    `;
+    expect(extractScssImportPaths(content)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  test('extracts @forward', () => {
+    expect(extractScssImportPaths(`@forward 'buttons';`)).toEqual(['buttons']);
+  });
+
+  test('extracts a legacy @import', () => {
+    expect(extractScssImportPaths(`@import 'legacy';`)).toEqual(['legacy']);
+  });
+
+  test('extracts each spec from a comma-separated @import list', () => {
+    expect(extractScssImportPaths(`@import 'a', 'b', 'c';`)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  test('keeps subdirectory specs intact', () => {
+    expect(extractScssImportPaths(`@use 'partials/typography';`)).toEqual([
+      'partials/typography',
+    ]);
+  });
+
+  test('ignores plain CSS @import: url(...)', () => {
+    expect(
+      extractScssImportPaths(`@import url("https://fonts.example/x.css");`)
+    ).toEqual([]);
+  });
+
+  test('ignores plain CSS @import: .css extension', () => {
+    expect(extractScssImportPaths(`@import 'reset.css';`)).toEqual([]);
+  });
+
+  test('ignores plain CSS @import: remote URL', () => {
+    expect(
+      extractScssImportPaths(`@import 'https://x.example/a.scss';`)
+    ).toEqual([]);
+  });
+
+  test('ignores plain CSS @import: trailing media query', () => {
+    expect(
+      extractScssImportPaths(
+        `@import "screen.css" screen and (min-width: 400px);`
+      )
+    ).toEqual([]);
+  });
+
+  test('ignores @import with a media query even without .css', () => {
+    expect(
+      extractScssImportPaths(`@import 'tablet' (min-width: 768px);`)
+    ).toEqual([]);
+  });
+
+  test('returns nothing for a file with no import directives', () => {
+    expect(extractScssImportPaths(`.box { color: red; }`)).toEqual([]);
+  });
+
+  test('does not treat other at-rules as imports', () => {
+    const content = `
+      @media (min-width: 1px) { .a { color: red; } }
+      @include fonts.body;
+      @mixin thing() { color: blue; }
+    `;
+    expect(extractScssImportPaths(content)).toEqual([]);
+  });
+
+  test('handles a multi-line @use ... with (...) block', () => {
+    const content = `@use 'shared' with (\n  $primary: blue,\n  $secondary: red\n);`;
+    expect(extractScssImportPaths(content)).toEqual(['shared']);
+  });
+
+  test('keeps the path for @forward with an `as prefix-*`', () => {
+    expect(extractScssImportPaths(`@forward 'src/list' as list-*;`)).toEqual([
+      'src/list',
+    ]);
+  });
+
+  test('parses an @import list with irregular spacing and mixed quotes', () => {
+    expect(extractScssImportPaths(`@import "a","b" ,  'c';`)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  test('ignores a commented-out directive (line comment)', () => {
+    expect(extractScssImportPaths(`// @use 'commented';\n.box {}`)).toEqual([]);
+  });
+
+  test('ignores a commented-out directive (block comment)', () => {
+    expect(
+      extractScssImportPaths(`/* @use 'blockcommented'; */\n.box {}`)
+    ).toEqual([]);
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.test.ts
@@ -59,6 +59,11 @@ describe('extractScssImportPaths', () => {
     ).toEqual([]);
   });
 
+  test('ignores plain CSS @import case-insensitively (.CSS / HTTP://)', () => {
+    expect(extractScssImportPaths(`@import 'reset.CSS';`)).toEqual([]);
+    expect(extractScssImportPaths(`@import 'HTTP://x.example/a';`)).toEqual([]);
+  });
+
   test('ignores plain CSS @import: trailing media query', () => {
     expect(
       extractScssImportPaths(

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.ts
@@ -39,11 +39,13 @@ const isSassImportSpec = (segment: string): string | null => {
     return null;
   }
 
-  // Sass does not inline CSS-extension or remote URLs.
+  // Sass does not inline CSS-extension or remote URLs. Compare case-insensitively
+  // so `reset.CSS` / `HTTP://…` are treated the same as their lowercase forms.
+  const lower = spec.toLowerCase();
   if (
-    spec.endsWith('.css') ||
-    spec.startsWith('http://') ||
-    spec.startsWith('https://')
+    lower.endsWith('.css') ||
+    lower.startsWith('http://') ||
+    lower.startsWith('https://')
   ) {
     return null;
   }

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/extractScssImportPaths.ts
@@ -1,0 +1,90 @@
+import postcssScss from 'postcss-scss';
+
+/**
+ * Extracts the partial paths a SCSS file pulls in via `@use`, `@forward` and the
+ * legacy `@import`. These are the only directives that emit the loaded file's
+ * top-level CSS rules into the compiled output, so their classes are real,
+ * usable classes of the importing module (issue #90).
+ *
+ * Only the module URL is returned — namespaces (`as x`), config (`with (…)`),
+ * and member filters (`show`/`hide`) are irrelevant to which CSS rules surface.
+ *
+ * `@import` is matched with Sass's own rule: a string is a Sass import (inlined
+ * at build time) UNLESS it has a `.css` extension, begins with `http://` /
+ * `https://`, is a `url(…)`, or carries a media query. Those are plain CSS
+ * imports that do not inline the file, so they contribute no classes.
+ */
+
+const LEADING_QUOTED_STRING = /^['"]([^'"]+)['"]/;
+
+const isSassImportSpec = (segment: string): string | null => {
+  const trimmed = segment.trim();
+
+  // `url(...)` is always a plain CSS import.
+  if (/^url\s*\(/i.test(trimmed)) {
+    return null;
+  }
+
+  const leading = trimmed.match(LEADING_QUOTED_STRING);
+  if (!leading?.[1]) {
+    return null;
+  }
+
+  const spec = leading[1];
+
+  // Anything after the closing quote (e.g. a media query) marks a plain CSS
+  // import that is not inlined.
+  const rest = trimmed.slice(leading[0].length).trim();
+  if (rest.length > 0) {
+    return null;
+  }
+
+  // Sass does not inline CSS-extension or remote URLs.
+  if (
+    spec.endsWith('.css') ||
+    spec.startsWith('http://') ||
+    spec.startsWith('https://')
+  ) {
+    return null;
+  }
+
+  return spec;
+};
+
+export const extractScssImportPaths = (cssContent: string): string[] => {
+  const paths: string[] = [];
+
+  let root: ReturnType<typeof postcssScss.parse>;
+  try {
+    root = postcssScss.parse(cssContent);
+  } catch {
+    // A malformed partial should never break class extraction for the module.
+    return paths;
+  }
+
+  root.walkAtRules((atRule) => {
+    const name = atRule.name.toLowerCase();
+
+    if (name === 'use' || name === 'forward') {
+      // `@use`/`@forward` take exactly one module URL, optionally followed by
+      // `as …`, `with (…)`, `show …` or `hide …` — all irrelevant here.
+      const match = atRule.params.match(LEADING_QUOTED_STRING);
+      if (match?.[1]) {
+        paths.push(match[1]);
+      }
+      return;
+    }
+
+    if (name === 'import') {
+      // `@import` may list several comma-separated specs.
+      for (const segment of atRule.params.split(',')) {
+        const spec = isSassImportSpec(segment);
+        if (spec) {
+          paths.push(spec);
+        }
+      }
+    }
+  });
+
+  return paths;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/index.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/index.ts
@@ -1,0 +1,3 @@
+export { collectPartialClasses } from './collectPartialClasses.js';
+export { extractScssImportPaths } from './extractScssImportPaths.js';
+export { resolveScssImport } from './resolveScssImport.js';

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/resolveScssImport.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/resolveScssImport.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { resolveScssImport } from './resolveScssImport.js';
+
+let root: string;
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-scss-'));
+  fs.mkdirSync(path.join(root, 'sub'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'pkg'), { recursive: true });
+
+  fs.writeFileSync(path.join(root, '_partial.scss'), '.p {}');
+  fs.writeFileSync(path.join(root, 'plain.scss'), '.q {}');
+  fs.writeFileSync(path.join(root, 'styles.css'), '.r {}');
+  fs.writeFileSync(path.join(root, 'sub', '_nested.scss'), '.n {}');
+  fs.writeFileSync(path.join(root, 'pkg', '_index.scss'), '.i {}');
+});
+
+afterAll(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('resolveScssImport', () => {
+  test('resolves a partial by its underscore name', () => {
+    expect(resolveScssImport('partial', root)).toBe(
+      path.join(root, '_partial.scss')
+    );
+  });
+
+  test('resolves a non-underscore file', () => {
+    expect(resolveScssImport('plain', root)).toBe(
+      path.join(root, 'plain.scss')
+    );
+  });
+
+  test('resolves an explicit extension by stripping then re-trying the partial rules', () => {
+    expect(resolveScssImport('partial.scss', root)).toBe(
+      path.join(root, '_partial.scss')
+    );
+  });
+
+  test('resolves a .css file', () => {
+    expect(resolveScssImport('styles', root)).toBe(
+      path.join(root, 'styles.css')
+    );
+  });
+
+  test('resolves a partial inside a subdirectory', () => {
+    expect(resolveScssImport('sub/nested', root)).toBe(
+      path.join(root, 'sub', '_nested.scss')
+    );
+  });
+
+  test('resolves a directory to its _index file', () => {
+    expect(resolveScssImport('pkg', root)).toBe(
+      path.join(root, 'pkg', '_index.scss')
+    );
+  });
+
+  test('returns null for a missing partial', () => {
+    expect(resolveScssImport('does-not-exist', root)).toBeNull();
+  });
+
+  test('prefers the underscore partial over a directory index of the same name', () => {
+    // `_partial.scss` exists; no `partial/` dir — must still resolve the file.
+    expect(resolveScssImport('partial', root)).toBe(
+      path.join(root, '_partial.scss')
+    );
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/scssImports/resolveScssImport.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/scssImports/resolveScssImport.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolves a SCSS `@use`/`@forward`/`@import` spec to an absolute file path,
+ * following Sass's load-path rules relative to the importing file's directory:
+ *
+ *  - a leading underscore marks a partial, so both `_name.ext` and `name.ext`
+ *    are tried;
+ *  - the `.scss`, `.sass` and `.css` extensions are tried in that order;
+ *  - a spec pointing at a directory resolves to its `_index` / `index` file.
+ *
+ * Returns the first existing file, or `null` when nothing matches (a missing
+ * partial must not break the run).
+ */
+
+const EXTENSIONS = ['.scss', '.sass', '.css'] as const;
+
+const candidateFilesFor = (basePath: string): string[] => {
+  const dir = path.dirname(basePath);
+  const name = path.basename(basePath);
+
+  const candidates: string[] = [];
+
+  // Direct file: `_name.ext` (partial) takes precedence over `name.ext`.
+  if (!name.startsWith('_')) {
+    for (const ext of EXTENSIONS) {
+      candidates.push(path.join(dir, `_${name}${ext}`));
+    }
+  }
+  for (const ext of EXTENSIONS) {
+    candidates.push(path.join(dir, `${name}${ext}`));
+  }
+
+  // Directory index: `name/_index.ext` then `name/index.ext`.
+  for (const ext of EXTENSIONS) {
+    candidates.push(path.join(basePath, `_index${ext}`));
+  }
+  for (const ext of EXTENSIONS) {
+    candidates.push(path.join(basePath, `index${ext}`));
+  }
+
+  return candidates;
+};
+
+export const resolveScssImport = (
+  spec: string,
+  fromFileDir: string
+): string | null => {
+  // Strip an explicit extension so we can apply the partial/extension rules
+  // uniformly; if the author wrote `shared.scss` we still try `_shared.scss`.
+  const withoutExt = spec.replace(/\.(scss|sass|css)$/i, '');
+  const basePath = path.resolve(fromFileDir, withoutExt);
+
+  for (const candidate of candidateFilesFor(basePath)) {
+    try {
+      if (fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    } catch {
+      // Not present — try the next candidate.
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Problem

Fixes #90. When a SCSS module pulls in a partial via `@use`, `@forward` or the legacy `@import`, the partial's top-level rules are emitted into the module's compiled CSS — so those classes are real, usable classes. The tool only parsed the module file itself, so it falsely reported imported classes as **non-existent**.

```scss
/* _shared.scss */ .box { color: red; }
/* Foo.module.scss */ @use 'shared';
```
```tsx
import styles from './Foo.module.scss'
export const Foo = () => <div className={styles.box} />  // .box was wrongly flagged
```

## Fix

New `scssImports` utility under `getUnusedClassesFromCss/utils/`:

- **`extractScssImportPaths`** — pulls module specs out of `@use`/`@forward`/`@import`. Plain-CSS `@import`s are skipped per Sass's own rule (`.css` extension, `url(...)`, `http(s)://`, or a trailing media query).
- **`resolveScssImport`** — resolves a spec to a file using Sass load rules: `_name` partials, `.scss/.sass/.css` extensions, and directory `_index`.
- **`collectPartialClasses`** — walks the import graph transitively (BFS) with a visited-set guard against cycles (legal with `@import`) and diamonds. Non-Sass files are skipped by extension.

Wired into both branches:
- **non-existent**: partial classes count as existing.
- **unused**: partial classes are seeded as used, so a local class sharing a name isn't flagged. Classes that exist **only** in a partial are never unused candidates — the importing module doesn't own them.

## Tests

- E2E (`scssAtRuleImports.test.ts`): `@use`, namespaced `@use`, `@forward` chained through `_index`, legacy `@import`, subdirectory partials, diamond dedup, `@import` cycle termination, missing partial, plus two guards that a genuinely missing class and a genuinely unused local class are still reported.
- Unit tests for `extractScssImportPaths`, `resolveScssImport`, `collectPartialClasses` covering parsing edge cases (comments, multi-line `with`, `as *`, media queries) and resolution/recursion edge cases.

All 984 tests pass; `check:all` (format, lint, types, tests) is green.