### PR TITLE
fix: treat classes inside a bare :global block/switch as global (#91)

### DIFF
--- a/.changeset/fix-global-block-classes.md
+++ b/.changeset/fix-global-block-classes.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Stop reporting classes inside a bare `:global { ... }` block (or `:global .switch` form) as unused (#91). The bare `:global` switch makes nested classes global, so they are no longer flagged. The function form `:global(.foo)` is unchanged.

--- a/src/__tests__/noError/GlobalBlock/GlobalBlock.module.scss
+++ b/src/__tests__/noError/GlobalBlock/GlobalBlock.module.scss
@@ -1,0 +1,19 @@
+.localUsed {
+  color: blue;
+}
+
+:global {
+  .globalThing {
+    color: red;
+  }
+
+  .anotherGlobal {
+    .nestedGlobal {
+      color: green;
+    }
+  }
+}
+
+:global .switchGlobal {
+  color: pink;
+}

--- a/src/__tests__/noError/GlobalBlock/GlobalBlock.module.scss
+++ b/src/__tests__/noError/GlobalBlock/GlobalBlock.module.scss
@@ -12,6 +12,12 @@
       color: green;
     }
   }
+
+  @media (min-width: 600px) {
+    .globalInMedia {
+      color: orange;
+    }
+  }
 }
 
 :global .switchGlobal {

--- a/src/__tests__/noError/GlobalBlock/GlobalBlock.tsx
+++ b/src/__tests__/noError/GlobalBlock/GlobalBlock.tsx
@@ -1,0 +1,3 @@
+import styles from './GlobalBlock.module.scss';
+
+export const GlobalBlock: React.FC = () => <div className={styles.localUsed} />;

--- a/src/__tests__/noError/noError.test.ts
+++ b/src/__tests__/noError/noError.test.ts
@@ -13,6 +13,7 @@ describe('Components without errors', () => {
     'PlainScss',
     'PlainSass',
     'GlobalClasses',
+    'GlobalBlock',
     'Animations',
     'Complex',
     'Media',

--- a/src/__tests__/withError/GlobalBlock/GlobalBlock.module.scss
+++ b/src/__tests__/withError/GlobalBlock/GlobalBlock.module.scss
@@ -16,6 +16,12 @@
       color: green;
     }
   }
+
+  @media (min-width: 600px) {
+    .globalInMedia {
+      color: orange;
+    }
+  }
 }
 
 :global .switchGlobal {

--- a/src/__tests__/withError/GlobalBlock/GlobalBlock.module.scss
+++ b/src/__tests__/withError/GlobalBlock/GlobalBlock.module.scss
@@ -1,0 +1,23 @@
+.usedClass {
+  color: blue;
+}
+
+.unusedClass {
+  color: black;
+}
+
+:global {
+  .globalThing {
+    color: red;
+  }
+
+  .anotherGlobal {
+    .nestedGlobal {
+      color: green;
+    }
+  }
+}
+
+:global .switchGlobal {
+  color: pink;
+}

--- a/src/__tests__/withError/GlobalBlock/GlobalBlock.tsx
+++ b/src/__tests__/withError/GlobalBlock/GlobalBlock.tsx
@@ -1,0 +1,3 @@
+import styles from './GlobalBlock.module.scss';
+
+export const GlobalBlock: React.FC = () => <div className={styles.usedClass} />;

--- a/src/__tests__/withError/withError.test.ts
+++ b/src/__tests__/withError/withError.test.ts
@@ -74,6 +74,25 @@ describe('Component with errors', () => {
     expect(result.stdout).not.toMatch(/^\s+\.usedClass2$/m);
   });
 
+  test('reports a local unused class but not classes inside a :global block (issue #91)', () => {
+    const result = runCheckUnusedCss('src/__tests__/withError/GlobalBlock');
+
+    expect(result.exitCode).toBe(1);
+
+    // The genuinely unused local class is reported.
+    expect(result.stdout).toMatch(/:\d+:\d+ - \.unusedClass$/m);
+
+    // Classes living inside a bare `:global` block/switch are global and must
+    // never be reported as unused.
+    expect(result.stdout).not.toMatch(/\.globalThing/);
+    expect(result.stdout).not.toMatch(/\.anotherGlobal/);
+    expect(result.stdout).not.toMatch(/\.nestedGlobal/);
+    expect(result.stdout).not.toMatch(/\.switchGlobal/);
+
+    // The used local class is not reported either.
+    expect(result.stdout).not.toMatch(/^\s+\.usedClass$/m);
+  });
+
   test('shows error for unused class in complex selectors', () => {
     const result = runCheckUnusedCss('src/__tests__/withError/Complex');
 

--- a/src/__tests__/withError/withError.test.ts
+++ b/src/__tests__/withError/withError.test.ts
@@ -87,6 +87,7 @@ describe('Component with errors', () => {
     expect(result.stdout).not.toMatch(/\.globalThing/);
     expect(result.stdout).not.toMatch(/\.anotherGlobal/);
     expect(result.stdout).not.toMatch(/\.nestedGlobal/);
+    expect(result.stdout).not.toMatch(/\.globalInMedia/);
     expect(result.stdout).not.toMatch(/\.switchGlobal/);
 
     // The used local class is not reported either.

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClassAncestry.ts
@@ -1,6 +1,7 @@
 import postcssScss from 'postcss-scss';
 import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
 import { extractClassNamesFromSelector } from './utils/extractClassNamesFromRule.js';
+import { isInsideGlobalScope } from './utils/isInsideGlobalScope.js';
 import {
   getParentClassName,
   resolveAmpersandSelector,
@@ -31,6 +32,11 @@ export const extractCssClassAncestry = (cssContent: string): ClassAncestry => {
 
   root.walkRules((rule) => {
     if (rule.source?.start && ignoredLines.has(rule.source.start.line)) {
+      return;
+    }
+
+    // A `:global` block makes its children global; they have no local ancestry.
+    if (isInsideGlobalScope(rule)) {
       return;
     }
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -414,6 +414,30 @@ describe('extractCssClasses (integration, real pipeline)', () => {
         )
       ).toEqual(sorted(['localAfter']));
     });
+
+    test('G11: class under an at-rule inside a `:global {}` block stays global', () => {
+      // The class is nested under `@media`, whose parent is `:global`; the
+      // ancestor walk must step through the at-rule to see the switch.
+      expect(
+        extractSorted(
+          ':global { @media (min-width: 1px) { .g { color: red; } } }'
+        )
+      ).toEqual([]);
+    });
+
+    test('G12: at-rule inside a `:global .scoped` switch stays global', () => {
+      expect(
+        extractSorted(
+          ':global .scoped { @media screen { .deep { color: red; } } }'
+        )
+      ).toEqual([]);
+    });
+
+    test('G13 (no regression): a class under an at-rule with no `:global` is local', () => {
+      expect(
+        extractSorted('@media screen { .localInMedia { color: red; } }')
+      ).toEqual(sorted(['localInMedia']));
+    });
   });
 
   describe('nested selectors starting with a combinator', () => {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -348,13 +348,13 @@ describe('extractCssClasses (integration, real pipeline)', () => {
     // must NOT be extracted as local. The function form `:global(.foo)` is
     // unaffected (already handled) and is covered by separate regression cases.
 
-    test('G1: class inside a `:global {}` block is not extracted', () => {
+    test('class inside a `:global {}` block is not extracted', () => {
       expect(extractSorted(':global { .globalThing { color: red; } }')).toEqual(
         []
       );
     });
 
-    test('G2: local class outside the block is kept; global one is dropped', () => {
+    test('local class outside the block is kept; global one is dropped', () => {
       expect(
         extractSorted(
           '.localUsed { color: blue; } :global { .globalThing { color: red; } }'
@@ -362,41 +362,41 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual(sorted(['localUsed']));
     });
 
-    test('G3: multiple classes inside a `:global {}` block are all dropped', () => {
+    test('multiple classes inside a `:global {}` block are all dropped', () => {
       expect(
         extractSorted(':global { .a { color: red; } .b { color: blue; } }')
       ).toEqual([]);
     });
 
-    test('G4: deep nesting inside a `:global {}` block stays global', () => {
+    test('deep nesting inside a `:global {}` block stays global', () => {
       expect(extractSorted(':global { .a { .b { color: red; } } }')).toEqual(
         []
       );
     });
 
-    test('G5: bare `:global .scoped` switch keeps no class', () => {
+    test('bare `:global .scoped` switch keeps no class', () => {
       expect(extractSorted(':global .scoped { color: red; }')).toEqual([]);
     });
 
-    test('G6: nested rule under a `:global .scoped` switch stays global', () => {
+    test('nested rule under a `:global .scoped` switch stays global', () => {
       expect(
         extractSorted(':global .scoped { .deep { color: red; } }')
       ).toEqual([]);
     });
 
-    test('G7: local class left of a bare `:global` switch is kept', () => {
+    test('local class left of a bare `:global` switch is kept', () => {
       expect(extractSorted('.local :global .after { color: red; }')).toEqual(
         sorted(['local'])
       );
     });
 
-    test('G8: a local block containing a `:global {}` block keeps only the local class', () => {
+    test('a local block containing a `:global {}` block keeps only the local class', () => {
       expect(
         extractSorted('.local { :global { .globalThing { color: red; } } }')
       ).toEqual(sorted(['local']));
     });
 
-    test('G9 (no regression): function form `:global(.foo)` still strips only the global part', () => {
+    test('no regression: function form `:global(.foo)` still strips only the global part', () => {
       // `:global(.foo) .bar` → `.foo` global, `.bar` local (stays local even
       // when expressed as a nested block).
       expect(extractSorted(':global(.foo) .bar { color: red; }')).toEqual(
@@ -407,7 +407,7 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       );
     });
 
-    test('G10: sibling local rule after a `:global {}` block is still extracted', () => {
+    test('sibling local rule after a `:global {}` block is still extracted', () => {
       expect(
         extractSorted(
           ':global { .g { color: red; } } .localAfter { color: blue; }'
@@ -415,7 +415,7 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual(sorted(['localAfter']));
     });
 
-    test('G11: class under an at-rule inside a `:global {}` block stays global', () => {
+    test('class under an at-rule inside a `:global {}` block stays global', () => {
       // The class is nested under `@media`, whose parent is `:global`; the
       // ancestor walk must step through the at-rule to see the switch.
       expect(
@@ -425,7 +425,7 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual([]);
     });
 
-    test('G12: at-rule inside a `:global .scoped` switch stays global', () => {
+    test('at-rule inside a `:global .scoped` switch stays global', () => {
       expect(
         extractSorted(
           ':global .scoped { @media screen { .deep { color: red; } } }'
@@ -433,7 +433,7 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual([]);
     });
 
-    test('G13 (no regression): a class under an at-rule with no `:global` is local', () => {
+    test('no regression: a class under an at-rule with no `:global` is local', () => {
       expect(
         extractSorted('@media screen { .localInMedia { color: red; } }')
       ).toEqual(sorted(['localInMedia']));

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -342,6 +342,80 @@ describe('extractCssClasses (integration, real pipeline)', () => {
     });
   });
 
+  describe(':global block and switch forms scope classes globally (issue #91)', () => {
+    // Bare `:global` (no parens) is a scope switch: everything to its right —
+    // in the same selector AND in nested rules — is global, so those classes
+    // must NOT be extracted as local. The function form `:global(.foo)` is
+    // unaffected (already handled) and is covered by separate regression cases.
+
+    test('G1: class inside a `:global {}` block is not extracted', () => {
+      expect(extractSorted(':global { .globalThing { color: red; } }')).toEqual(
+        []
+      );
+    });
+
+    test('G2: local class outside the block is kept; global one is dropped', () => {
+      expect(
+        extractSorted(
+          '.localUsed { color: blue; } :global { .globalThing { color: red; } }'
+        )
+      ).toEqual(sorted(['localUsed']));
+    });
+
+    test('G3: multiple classes inside a `:global {}` block are all dropped', () => {
+      expect(
+        extractSorted(':global { .a { color: red; } .b { color: blue; } }')
+      ).toEqual([]);
+    });
+
+    test('G4: deep nesting inside a `:global {}` block stays global', () => {
+      expect(extractSorted(':global { .a { .b { color: red; } } }')).toEqual(
+        []
+      );
+    });
+
+    test('G5: bare `:global .scoped` switch keeps no class', () => {
+      expect(extractSorted(':global .scoped { color: red; }')).toEqual([]);
+    });
+
+    test('G6: nested rule under a `:global .scoped` switch stays global', () => {
+      expect(
+        extractSorted(':global .scoped { .deep { color: red; } }')
+      ).toEqual([]);
+    });
+
+    test('G7: local class left of a bare `:global` switch is kept', () => {
+      expect(extractSorted('.local :global .after { color: red; }')).toEqual(
+        sorted(['local'])
+      );
+    });
+
+    test('G8: a local block containing a `:global {}` block keeps only the local class', () => {
+      expect(
+        extractSorted('.local { :global { .globalThing { color: red; } } }')
+      ).toEqual(sorted(['local']));
+    });
+
+    test('G9 (no regression): function form `:global(.foo)` still strips only the global part', () => {
+      // `:global(.foo) .bar` → `.foo` global, `.bar` local (stays local even
+      // when expressed as a nested block).
+      expect(extractSorted(':global(.foo) .bar { color: red; }')).toEqual(
+        sorted(['bar'])
+      );
+      expect(extractSorted(':global(.foo) { .bar { color: red; } }')).toEqual(
+        sorted(['bar'])
+      );
+    });
+
+    test('G10: sibling local rule after a `:global {}` block is still extracted', () => {
+      expect(
+        extractSorted(
+          ':global { .g { color: red; } } .localAfter { color: blue; }'
+        )
+      ).toEqual(sorted(['localAfter']));
+    });
+  });
+
   describe('nested selectors starting with a combinator', () => {
     test('child combinator (>) at the start of a nested selector', () => {
       expect(extractSorted('.wrapper { > .item { color: red; } }')).toEqual(

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
@@ -4,6 +4,7 @@ import {
   extractClassNamesFromAtRule,
   extractClassNamesFromRule,
 } from './utils/extractClassNamesFromRule.js';
+import { isInsideGlobalScope } from './utils/isInsideGlobalScope.js';
 import { isSelectorBearingAtRule } from './utils/isSelectorBearingAtRule.js';
 
 export type CssClassInfo = {
@@ -25,6 +26,11 @@ export const extractCssClasses = (cssContent: string): string[] => {
 
   root.walkRules((rule) => {
     if (rule.source?.start && ignoredLines.has(rule.source.start.line)) {
+      return;
+    }
+
+    // Classes inside a bare `:global { … }` block/switch are global, not local.
+    if (isInsideGlobalScope(rule)) {
       return;
     }
 
@@ -70,6 +76,11 @@ export const extractCssClassesWithLocations = (
 
   root.walkRules((rule) => {
     if (rule.source?.start && ignoredLines.has(rule.source.start.line)) {
+      return;
+    }
+
+    // Classes inside a bare `:global { … }` block/switch are global, not local.
+    if (isInsideGlobalScope(rule)) {
       return;
     }
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -1,4 +1,3 @@
-import { createParser, type Parser } from 'css-selector-parser';
 import type { AtRule, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
 import { findClassNamesInSelector } from './findClassNamesInSelector.js';
@@ -6,17 +5,7 @@ import {
   getParentClassName,
   resolveAmpersandSelector,
 } from './resolveAmpersandSelector.js';
-
-/**
- * Non-strict mode lets the parser accept identifiers that start with two
- * hyphens (e.g. `.--reversed`, `.root.--variant`) — a common CSS-Modules
- * modifier convention that strict mode rejects, which would otherwise make the
- * `catch` below silently drop the whole rule. Non-strict mode is also more
- * tolerant of truncated selectors, extracting the recognizable class names
- * instead of discarding the rule; for an unused-CSS analyzer, erring toward
- * "this class is used" is safer than losing a definition.
- */
-const parseSelector: Parser = createParser({ strict: false });
+import { parseSelector } from './selectorParser.js';
 
 /**
  * Resolve a raw selector string (already ampersand-resolved against its parent)

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import type { AstSelector, Parser } from 'css-selector-parser';
 import { createParser } from 'css-selector-parser';
 import { findClassNamesInSelector } from './findClassNamesInSelector.js';
+import { parseSelector as globalAwareParser } from './selectorParser.js';
 
 const parseSelector: Parser = createParser();
 
@@ -321,6 +322,28 @@ describe('findClassNamesInSelector', () => {
         'modal-content',
         'modal-body',
       ]);
+    });
+  });
+
+  describe('should stop collecting at a bare :global switch', () => {
+    // These use the global-aware parser; a bare `:global` switch turns every
+    // compound to its right into the global scope, so those classes must not be
+    // collected.
+    test('drops classes to the right of a bare :global switch', () => {
+      const selector = globalAwareParser('.local :global .after');
+      expect(findClassNamesInSelector(selector)).toEqual(['local']);
+    });
+
+    test('drops everything when :global leads the selector', () => {
+      const selector = globalAwareParser(':global .scoped');
+      expect(findClassNamesInSelector(selector)).toEqual([]);
+    });
+
+    test('keeps a class trailing the function form :global(.foo)', () => {
+      // The function form carries an argument and is NOT a switch, so `.bar`
+      // stays local; the inner `.foo` is global and is not collected.
+      const selector = globalAwareParser(':global(.foo) .bar');
+      expect(findClassNamesInSelector(selector)).toEqual(['bar']);
     });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -9,6 +9,19 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
 
   const extractClassNamesFromRule = (rule: AstRule): void => {
     for (const item of rule.items) {
+      // A bare `:global` (no argument) is a CSS-Modules scope SWITCH: every
+      // compound to its right — in this selector and in its nested rules — is
+      // global, so stop collecting this branch. The function form
+      // `:global(.foo)` carries an argument and is left alone (its inner class
+      // is global, not collected, but `.foo .bar` keeps `.bar` local).
+      if (
+        item.type === 'PseudoClass' &&
+        item.name === 'global' &&
+        !item.argument
+      ) {
+        return;
+      }
+
       if (item.type === 'ClassName') {
         classNames.push(item.name);
       } else if (

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -1,4 +1,5 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
+import { isGlobalSwitchItem } from './selectorParser.js';
 
 export const findClassNamesInSelector = (selector: AstSelector): string[] => {
   if (!selector.rules.length) {
@@ -9,16 +10,11 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
 
   const extractClassNamesFromRule = (rule: AstRule): void => {
     for (const item of rule.items) {
-      // A bare `:global` (no argument) is a CSS-Modules scope SWITCH: every
-      // compound to its right — in this selector and in its nested rules — is
-      // global, so stop collecting this branch. The function form
-      // `:global(.foo)` carries an argument and is left alone (its inner class
-      // is global, not collected, but `.foo .bar` keeps `.bar` local).
-      if (
-        item.type === 'PseudoClass' &&
-        item.name === 'global' &&
-        !item.argument
-      ) {
+      // A bare `:global` switch makes every compound to its right — in this
+      // selector and in its nested rules — global, so stop collecting this
+      // branch. (The function form `:global(.foo)` is not a switch; its inner
+      // class is simply not collected, while `:global(.foo) .bar` keeps `.bar`.)
+      if (isGlobalSwitchItem(item)) {
         return;
       }
 

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import type { Rule } from 'postcss';
+import postcssScss from 'postcss-scss';
+import { isInsideGlobalScope } from './isInsideGlobalScope.js';
+
+/** Parse SCSS and return the first rule whose selector matches `selector`. */
+const ruleBySelector = (css: string, selector: string): Rule => {
+  const root = postcssScss.parse(css);
+  let found: Rule | undefined;
+  root.walkRules((rule) => {
+    if (!found && rule.selector === selector) {
+      found = rule;
+    }
+  });
+  if (!found) {
+    throw new Error(`No rule with selector "${selector}" in:\n${css}`);
+  }
+  return found;
+};
+
+describe('isInsideGlobalScope', () => {
+  test('a top-level rule is not in global scope', () => {
+    expect(isInsideGlobalScope(ruleBySelector('.local {}', '.local'))).toBe(
+      false
+    );
+  });
+
+  test('a rule inside a bare `:global {}` block is in global scope', () => {
+    const rule = ruleBySelector(':global { .g {} }', '.g');
+    expect(isInsideGlobalScope(rule)).toBe(true);
+  });
+
+  test('a deeply nested rule inside a `:global {}` block is in global scope', () => {
+    const rule = ruleBySelector(':global { .a { .b {} } }', '.b');
+    expect(isInsideGlobalScope(rule)).toBe(true);
+  });
+
+  test('a rule under a `:global .scoped` switch is in global scope', () => {
+    const rule = ruleBySelector(':global .scoped { .deep {} }', '.deep');
+    expect(isInsideGlobalScope(rule)).toBe(true);
+  });
+
+  test('the function form `:global(.foo)` does NOT put nested rules in global scope', () => {
+    const rule = ruleBySelector(':global(.foo) { .bar {} }', '.bar');
+    expect(isInsideGlobalScope(rule)).toBe(false);
+  });
+
+  test('a sibling rule after a `:global {}` block is not in global scope', () => {
+    const rule = ruleBySelector(
+      ':global { .g {} } .localAfter {}',
+      '.localAfter'
+    );
+    expect(isInsideGlobalScope(rule)).toBe(false);
+  });
+
+  test('a local rule wrapping a `:global {}` block is not itself in global scope', () => {
+    const rule = ruleBySelector('.local { :global { .g {} } }', '.local');
+    expect(isInsideGlobalScope(rule)).toBe(false);
+  });
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
@@ -57,4 +57,27 @@ describe('isInsideGlobalScope', () => {
     const rule = ruleBySelector('.local { :global { .g {} } }', '.local');
     expect(isInsideGlobalScope(rule)).toBe(false);
   });
+
+  test('a rule nested under an at-rule inside a `:global {}` block is in global scope', () => {
+    // The `.g` rule's direct parent is the `@media` at-rule, not `:global`, so
+    // the ancestor walk must step through the at-rule to find the switch.
+    const rule = ruleBySelector(
+      ':global { @media (min-width: 1px) { .g {} } }',
+      '.g'
+    );
+    expect(isInsideGlobalScope(rule)).toBe(true);
+  });
+
+  test('a rule under an at-rule inside a `:global .scoped` switch is in global scope', () => {
+    const rule = ruleBySelector(
+      ':global .scoped { @media screen { .deep {} } }',
+      '.deep'
+    );
+    expect(isInsideGlobalScope(rule)).toBe(true);
+  });
+
+  test('a rule under an at-rule but NOT inside any `:global` switch is not in global scope', () => {
+    const rule = ruleBySelector('@media screen { .local {} }', '.local');
+    expect(isInsideGlobalScope(rule)).toBe(false);
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
@@ -1,22 +1,11 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
 import type { Container, Document, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
-import { parseSelector } from './selectorParser.js';
+import { isGlobalSwitchItem, parseSelector } from './selectorParser.js';
 
-const ruleHasGlobalSwitch = (rule: AstRule): boolean => {
-  for (const item of rule.items) {
-    // A bare `:global` (no argument) is the scope switch; `:global(.foo)` (with
-    // argument) is the function form and does NOT switch nested rules to global.
-    if (
-      item.type === 'PseudoClass' &&
-      item.name === 'global' &&
-      !item.argument
-    ) {
-      return true;
-    }
-  }
-  return rule.nestedRule ? ruleHasGlobalSwitch(rule.nestedRule) : false;
-};
+const ruleHasGlobalSwitch = (rule: AstRule): boolean =>
+  rule.items.some(isGlobalSwitchItem) ||
+  (rule.nestedRule ? ruleHasGlobalSwitch(rule.nestedRule) : false);
 
 /**
  * Does this selector string contain a bare `:global` scope SWITCH at any point?
@@ -24,6 +13,12 @@ const ruleHasGlobalSwitch = (rule: AstRule): boolean => {
  * an ancestor defines global (not local) classes.
  */
 const selectorHasGlobalSwitch = (selector: string): boolean => {
+  // Cheap reject for the common case (no `:global` at all) — avoids a parser
+  // allocation on every ancestor of every rule in `:global`-free stylesheets.
+  if (!selector.includes(':global')) {
+    return false;
+  }
+
   let parsed: AstSelector;
   try {
     parsed = parseSelector(clearGlobalSelectors(selector));

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
@@ -1,0 +1,55 @@
+import type { AstRule, AstSelector } from 'css-selector-parser';
+import type { Rule } from 'postcss';
+import { clearGlobalSelectors } from './clearGlobalSelectors.js';
+import { parseSelector } from './selectorParser.js';
+
+const ruleHasGlobalSwitch = (rule: AstRule): boolean => {
+  for (const item of rule.items) {
+    // A bare `:global` (no argument) is the scope switch; `:global(.foo)` (with
+    // argument) is the function form and does NOT switch nested rules to global.
+    if (
+      item.type === 'PseudoClass' &&
+      item.name === 'global' &&
+      !item.argument
+    ) {
+      return true;
+    }
+  }
+  return rule.nestedRule ? ruleHasGlobalSwitch(rule.nestedRule) : false;
+};
+
+/**
+ * Does this selector string contain a bare `:global` scope SWITCH at any point?
+ * The bare form turns every nested rule's classes global, so a rule with such
+ * an ancestor defines global (not local) classes.
+ */
+const selectorHasGlobalSwitch = (selector: string): boolean => {
+  let parsed: AstSelector;
+  try {
+    parsed = parseSelector(clearGlobalSelectors(selector));
+  } catch {
+    return false;
+  }
+
+  return parsed.rules.some(ruleHasGlobalSwitch);
+};
+
+/**
+ * A rule lives in global scope when any ancestor rule opens a bare `:global`
+ * block/switch (e.g. `:global { .foo {} }` or `:global .scoped { .deep {} }`).
+ * SCSS nesting concatenates the child selector to the right of the switch, so
+ * the child is global too. The function form `:global(.foo) { .bar {} }` does
+ * NOT count — `.bar` stays local — which `selectorHasGlobalSwitch` reflects.
+ */
+export const isInsideGlobalScope = (rule: Rule): boolean => {
+  let parent = rule.parent;
+
+  while (parent && parent.type === 'rule') {
+    if (selectorHasGlobalSwitch((parent as Rule).selector)) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+
+  return false;
+};

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
@@ -1,5 +1,5 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
-import type { Rule } from 'postcss';
+import type { Container, Document, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
 import { parseSelector } from './selectorParser.js';
 
@@ -40,12 +40,20 @@ const selectorHasGlobalSwitch = (selector: string): boolean => {
  * SCSS nesting concatenates the child selector to the right of the switch, so
  * the child is global too. The function form `:global(.foo) { .bar {} }` does
  * NOT count — `.bar` stays local — which `selectorHasGlobalSwitch` reflects.
+ *
+ * At-rules between the switch and the class (`:global { @media … { .g {} } }`)
+ * are walked through, not stopped at: only `rule` ancestors carry a selector to
+ * test, but a non-`rule` ancestor must not end the walk or the `.g` above would
+ * be missed.
  */
 export const isInsideGlobalScope = (rule: Rule): boolean => {
-  let parent = rule.parent;
+  let parent: Container | Document | undefined = rule.parent;
 
-  while (parent && parent.type === 'rule') {
-    if (selectorHasGlobalSwitch((parent as Rule).selector)) {
+  while (parent) {
+    if (
+      parent.type === 'rule' &&
+      selectorHasGlobalSwitch((parent as Rule).selector)
+    ) {
       return true;
     }
     parent = parent.parent;

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
@@ -1,15 +1,7 @@
-import {
-  type AstRule,
-  type AstSelector,
-  createParser,
-  type Parser,
-} from 'css-selector-parser';
+import type { AstRule, AstSelector } from 'css-selector-parser';
 import type { Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
-
-// Non-strict mode so double-dash modifier classes (`.--variant`) parse; see the
-// matching note in extractClassNamesFromRule.ts.
-const parseSelector: Parser = createParser({ strict: false });
+import { parseSelector } from './selectorParser.js';
 
 const getParentRule = (rule: Rule): Rule | null => {
   const { parent } = rule;

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
@@ -1,0 +1,21 @@
+import { createParser, type Parser } from 'css-selector-parser';
+
+/**
+ * Shared `css-selector-parser` instance for class extraction.
+ *
+ * - `strict: false` lets identifiers start with two hyphens (`.--reversed`,
+ *   `.root.--variant`) — a common CSS-Modules modifier convention strict mode
+ *   rejects — and tolerates truncated selectors, extracting the recognizable
+ *   classes instead of dropping the whole rule. For an unused-CSS analyzer,
+ *   erring toward "this class is used" is safer than losing a definition.
+ * - `baseSyntax: 'progressive'` with `pseudoClasses: { unknown: 'accept' }`
+ *   keeps the CSS-Modules `:global` switch (and any other non-standard
+ *   pseudo-class) from throwing, so `:global` parses into a `PseudoClass` node
+ *   that `findClassNamesInSelector` reads to mark the rest of the compound as
+ *   global. The function form `:global(.foo)` parses with a String argument and
+ *   its inner class is intentionally not collected.
+ */
+export const parseSelector: Parser = createParser({
+  strict: false,
+  syntax: { baseSyntax: 'progressive', pseudoClasses: { unknown: 'accept' } },
+});

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
@@ -1,4 +1,7 @@
+import type { AstRule } from 'css-selector-parser';
 import { createParser, type Parser } from 'css-selector-parser';
+
+type AstRuleItem = AstRule['items'][number];
 
 /**
  * Shared `css-selector-parser` instance for class extraction.
@@ -19,3 +22,12 @@ export const parseSelector: Parser = createParser({
   strict: false,
   syntax: { baseSyntax: 'progressive', pseudoClasses: { unknown: 'accept' } },
 });
+
+/**
+ * The single definition of a CSS-Modules scope SWITCH: a bare `:global` (no
+ * argument). Everything to its right — in the same selector and in nested rules
+ * — is global. The function form `:global(.foo)` carries an argument and is NOT
+ * a switch (`:global(.foo) .bar` keeps `.bar` local).
+ */
+export const isGlobalSwitchItem = (item: AstRuleItem): boolean =>
+  item.type === 'PseudoClass' && item.name === 'global' && !item.argument;


### PR DESCRIPTION
## Problem

Fixes #91. A class inside a bare `:global { ... }` block (or the `:global .switch` form) was reported as **unused**. The extractor only stripped the function form `:global(...)`; it never handled the bare `:global` scope switch, so classes nested under it were collected as local definitions and then flagged.

```scss
/* Foo.module.scss */
.localUsed { color: blue; }

:global {
  .globalThing { color: red; }   /* wrongly flagged as unused */
}
```

## Fix

A bare `:global` is a CSS-Modules **scope switch**: everything to its right — in the same selector *and* in nested rules — is global. The function form `:global(.foo)` is **not** a switch (`:global(.foo) .bar` keeps `.bar` local), so it is unchanged.

- **`selectorParser.ts`** — shared `css-selector-parser` configured with `strict: false` + `syntax: { baseSyntax: 'progressive', pseudoClasses: { unknown: 'accept' } }` so bare `:global` parses into a `PseudoClass` node instead of throwing. Reused everywhere a selector is parsed.
- **`findClassNamesInSelector`** — stops collecting a branch at a bare `:global` (a `PseudoClass` named `global` with no argument), covering the switch inside a rule's own selector (`.local :global .after` → keeps `.local`).
- **`isInsideGlobalScope`** — walks postcss ancestor rules; a rule nested under a `:global` switch ancestor defines global classes and is skipped. Wired into both `walkRules` loops in `extractCssClasses` and into the ancestry pass.

## Tests

- Integration (`extractCssClasses.integration.test.ts`, G1–G10): block form, deep nesting, bare switch, local-left-of-switch, local block wrapping a `:global` block, sibling local after the block, and a no-regression case for the function form.
- Unit: `isInsideGlobalScope` (ancestor walk incl. function-form negative) and `findClassNamesInSelector` (switch stops collection; function form keeps trailing class).
- E2E fixtures: `noError/GlobalBlock` (no false positive) and `withError/GlobalBlock` (a real unused local class is still reported while `:global` classes are not).

All 1010 tests pass; `check:all` (format, lint, types, tests) is green.
