### PR TITLE
fix: recognize classes defined with the :local(...) function form (#97)

### DIFF
--- a/.changeset/local-function-form.md
+++ b/.changeset/local-function-form.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Recognize classes defined with the `:local(...)` function form, like `:local(.active) { }` (#97). Such classes are no longer reported as non-existent.

--- a/src/__tests__/noError/LocalClasses/LocalClasses.module.scss
+++ b/src/__tests__/noError/LocalClasses/LocalClasses.module.scss
@@ -1,0 +1,11 @@
+:local(.active) {
+  color: red;
+}
+
+:local(.root.selected) {
+  color: blue;
+}
+
+:local(.parent .child) {
+  color: green;
+}

--- a/src/__tests__/noError/LocalClasses/LocalClasses.tsx
+++ b/src/__tests__/noError/LocalClasses/LocalClasses.tsx
@@ -1,0 +1,11 @@
+import styles from './LocalClasses.module.scss';
+
+export const LocalClasses: React.FC = () => (
+  <div className={styles.active}>
+    <div className={`${styles.root} ${styles.selected}`}>
+      <div className={styles.parent}>
+        <div className={styles.child} />
+      </div>
+    </div>
+  </div>
+);

--- a/src/__tests__/noError/noError.test.ts
+++ b/src/__tests__/noError/noError.test.ts
@@ -14,6 +14,7 @@ describe('Components without errors', () => {
     'PlainSass',
     'GlobalClasses',
     'GlobalBlock',
+    'LocalClasses',
     'Animations',
     'Complex',
     'Media',

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -572,4 +572,86 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       );
     });
   });
+
+  describe(':local(...) function form scopes classes locally (issue #97)', () => {
+    // The function form `:local(.foo)` explicitly marks its inner classes as
+    // local; they must be extracted. This mirrors `:global(.foo)`, whose inner
+    // classes are global and are dropped.
+
+    test('single class inside :local(...) is extracted', () => {
+      expect(extractSorted(':local(.active) { color: red; }')).toEqual(
+        sorted(['active'])
+      );
+    });
+
+    test('multiple compound classes inside :local(...) are extracted', () => {
+      expect(extractSorted(':local(.root.active) { color: red; }')).toEqual(
+        sorted(['root', 'active'])
+      );
+    });
+
+    test('descendant selector inside :local(...) is extracted', () => {
+      expect(extractSorted(':local(.a .b) { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('combinator inside :local(...) is extracted', () => {
+      expect(extractSorted(':local(.a > .b) { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('class trailing the :local(...) form stays local', () => {
+      expect(extractSorted(':local(.a) .b { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('class preceding the :local(...) form stays local', () => {
+      expect(extractSorted('.a :local(.b) { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('double-dash modifier inside :local(...) is extracted', () => {
+      expect(extractSorted(':local(.--reversed) { color: red; }')).toEqual(
+        sorted(['--reversed'])
+      );
+    });
+
+    test('a global class nested inside :local(...) is dropped', () => {
+      // `clearGlobalSelectors` strips the inner `:global(.g)` textually before
+      // parsing, leaving `:local(.a )`, so only the local `.a` survives.
+      expect(extractSorted(':local(.a :global(.g)) { color: red; }')).toEqual(
+        sorted(['a'])
+      );
+    });
+
+    test('bare `:local .active` switch form is extracted', () => {
+      // Already worked before the fix; guards against regression.
+      expect(extractSorted(':local .active { color: red; }')).toEqual(
+        sorted(['active'])
+      );
+    });
+
+    test('nested rules under a :local(...) parent are extracted', () => {
+      expect(
+        extractSorted(':local(.parent) { &.active { .child { color: red; } } }')
+      ).toEqual(sorted(['parent', 'active', 'child']));
+    });
+
+    test('selector list of :local(...) members is extracted', () => {
+      expect(extractSorted(':local(.a), :local(.b) { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('SCSS suffix concat under a :local(...) parent is extracted', () => {
+      // `&Black` joins to the local parent `button`, producing `buttonBlack`.
+      expect(
+        extractSorted(':local(.button) { &Black { color: red; } }')
+      ).toEqual(sorted(['button', 'buttonBlack']));
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
@@ -346,4 +346,33 @@ describe('findClassNamesInSelector', () => {
       expect(findClassNamesInSelector(selector)).toEqual(['bar']);
     });
   });
+
+  describe('should collect classes inside the :local(...) function form (issue #97)', () => {
+    // The function form `:local(.foo)` parses its argument as a String; those
+    // inner classes are explicitly local and must be collected.
+    test('collects a single class inside :local(...)', () => {
+      const selector = globalAwareParser(':local(.active)');
+      expect(findClassNamesInSelector(selector)).toEqual(['active']);
+    });
+
+    test('collects a compound class inside :local(...)', () => {
+      const selector = globalAwareParser(':local(.root.active)');
+      expect(findClassNamesInSelector(selector)).toEqual(['root', 'active']);
+    });
+
+    test('collects a descendant selector inside :local(...)', () => {
+      const selector = globalAwareParser(':local(.a .b)');
+      expect(findClassNamesInSelector(selector)).toEqual(['a', 'b']);
+    });
+
+    test('keeps a class trailing the :local(...) form', () => {
+      const selector = globalAwareParser(':local(.a) .b');
+      expect(findClassNamesInSelector(selector)).toEqual(['a', 'b']);
+    });
+
+    test('collects a double-dash modifier inside :local(...)', () => {
+      const selector = globalAwareParser(':local(.--reversed)');
+      expect(findClassNamesInSelector(selector)).toEqual(['--reversed']);
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -1,5 +1,20 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
-import { isGlobalSwitchItem } from './selectorParser.js';
+import { isGlobalSwitchItem, parseSelector } from './selectorParser.js';
+
+/**
+ * The CSS-Modules `:local(...)` function form marks its inner classes as local,
+ * so they must be collected. The parser captures the argument as a raw String
+ * (e.g. `:local(.a .b)` -> `.a .b`), so re-parse it and recurse. Any `:global(...)`
+ * nested inside is already stripped upstream by `clearGlobalSelectors`; if a raw
+ * argument still fails to parse, skip it rather than dropping the whole selector.
+ */
+export const findClassNamesInLocalArgument = (argument: string): string[] => {
+  try {
+    return findClassNamesInSelector(parseSelector(argument));
+  } catch {
+    return [];
+  }
+};
 
 export const findClassNamesInSelector = (selector: AstSelector): string[] => {
   if (!selector.rules.length) {
@@ -20,6 +35,17 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
 
       if (item.type === 'ClassName') {
         classNames.push(item.name);
+      } else if (
+        item.type === 'PseudoClass' &&
+        item.name === 'local' &&
+        item.argument &&
+        item.argument.type === 'String'
+      ) {
+        // The `:local(.foo)` function form scopes its inner classes as local
+        // (issue #97). The parser captures the argument as a raw String, so
+        // re-parse it to collect the classes. `:global(.foo)` keeps the opposite
+        // behavior: its String argument is intentionally left uncollected.
+        classNames.push(...findClassNamesInLocalArgument(item.argument.value));
       } else if (
         item.type === 'PseudoClass' &&
         item.argument &&

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.test.ts
@@ -270,4 +270,22 @@ describe('getParentClassName', () => {
       expect(getParentClassName(rule)).toBe('b');
     });
   });
+
+  describe('should treat a :local(...) parent as a plain class (issue #97)', () => {
+    test('resolves the class inside :local(.button)', () => {
+      const rule = createMockRule('&Black', {
+        type: 'rule',
+        selector: ':local(.button)',
+      });
+      expect(getParentClassName(rule)).toBe('button');
+    });
+
+    test('resolves the last class of a compound inside :local(...)', () => {
+      const rule = createMockRule('&-faded', {
+        type: 'rule',
+        selector: ':local(.root.--variant)',
+      });
+      expect(getParentClassName(rule)).toBe('--variant');
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/resolveAmpersandSelector.ts
@@ -1,6 +1,7 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
 import type { Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
+import { findClassNamesInLocalArgument } from './findClassNamesInSelector.js';
 import { parseSelector } from './selectorParser.js';
 
 const getParentRule = (rule: Rule): Rule | null => {
@@ -14,13 +15,26 @@ const getParentRule = (rule: Rule): Rule | null => {
 /**
  * Return the last direct class name of a parsed compound (the right-most
  * `ClassName` in its `items`), ignoring classes that live inside attribute
- * values or pseudo-class arguments (e.g. `[style*=".foo"]`, `:not(.fake)`).
+ * values or non-`:local` pseudo-class arguments (e.g. `[style*=".foo"]`,
+ * `:not(.fake)`). The CSS-Modules `:local(...)` function form is treated as a
+ * plain local class (issue #97), so `:local(.button)` yields `button` — letting
+ * it act as the parent of SCSS suffix concatenation like `&Black`.
  */
 const getLastClassNameOfRule = (rule: AstRule): string | null => {
   let lastClassName: string | null = null;
   for (const item of rule.items) {
     if (item.type === 'ClassName') {
       lastClassName = item.name;
+    } else if (
+      item.type === 'PseudoClass' &&
+      item.name === 'local' &&
+      item.argument &&
+      item.argument.type === 'String'
+    ) {
+      const localClasses = findClassNamesInLocalArgument(item.argument.value);
+      if (localClasses.length) {
+        lastClassName = localClasses[localClasses.length - 1] ?? lastClassName;
+      }
     }
   }
   return lastClassName;

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
@@ -16,7 +16,9 @@ type AstRuleItem = AstRule['items'][number];
  *   pseudo-class) from throwing, so `:global` parses into a `PseudoClass` node
  *   that `findClassNamesInSelector` reads to mark the rest of the compound as
  *   global. The function form `:global(.foo)` parses with a String argument and
- *   its inner class is intentionally not collected.
+ *   its inner class is intentionally not collected, while the `:local(.foo)`
+ *   function form has its String argument re-parsed so the inner class IS
+ *   collected (issue #97) — both handled in `findClassNamesInSelector`.
  */
 export const parseSelector: Parser = createParser({
   strict: false,


### PR DESCRIPTION
Fixes #97.

## Problem

Classes defined with the CSS-Modules `:local(...)` function form were falsely reported as non-existent:

```scss
:local(.active) {
  color: red;
}
```

```tsx
import styles from './a.module.scss'
export const A = () => <div className={styles.active} />
```

`check-unused-css src` reported `.active` as *"used in source files but non-existent in CSS"*.

**Root cause:** `css-selector-parser` captures the `:local(...)` argument as a raw `String` (e.g. `:local(.a .b)` → `.a .b`), not a parsed selector. The extractor only collected `ClassName` items and parsed `Selector` arguments (like `:not(.x)`), so the inner classes of `:local(...)` were never collected. The switch form `:local .active` already worked.

## Fix

- In `findClassNamesInSelector`, when a `PseudoClass` named `local` has a `String` argument, re-parse that string and recurse to collect its (local) classes. `:global(.foo)` keeps the opposite behavior — its inner class stays uncollected.
- In `resolveAmpersandSelector`, treat a `:local(...)` parent as a plain class so SCSS suffix concatenation resolves: `:local(.button) { &Black {} }` → `buttonBlack`.

Nested `:global(...)` inside `:local(...)` is already stripped textually upstream by `clearGlobalSelectors`, so `:local(.a :global(.g))` yields only `.a`.

## Tests

- `findClassNamesInSelector.test.ts` — unit coverage: single/compound/descendant classes, trailing class, double-dash modifier.
- `resolveAmpersandSelector.test.ts` — `:local(...)` as a suffix-concat parent.
- `extractCssClasses.integration.test.ts` — real-pipeline block covering combinators, selector lists, nested rules, the `:local` switch regression guard, and suffix concat under a `:local(...)` parent.
- e2e fixture `noError/LocalClasses` reproducing the exact issue example.

`bun run check:all` passes (format, lint, type, 1071 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)