### PR TITLE
fix: recognize :local(...) classes inside a bare :global block (#101)

### DIFF
--- a/.changeset/local-inside-global-block.md
+++ b/.changeset/local-inside-global-block.md
@@ -1,0 +1,5 @@
+---
+'check-unused-css': patch
+---
+
+Recognize `:local(...)` classes nested inside a bare `:global {}` block, like `:global { :local(.small) {} }` (#101). Such classes are no longer reported as non-existent.

--- a/src/__tests__/noError/LocalInGlobalBlock/LocalInGlobalBlock.module.scss
+++ b/src/__tests__/noError/LocalInGlobalBlock/LocalInGlobalBlock.module.scss
@@ -1,0 +1,23 @@
+// A `:local(...)` form nested inside a bare `:global {}` block re-scopes its
+// classes back to local, so they are real module classes (issue #101).
+:global {
+  :local(.small) {
+    color: red;
+  }
+
+  :local(.medium.active) {
+    color: blue;
+  }
+
+  // A bare `:local` switch inside the global block also re-scopes descendants.
+  :local {
+    .large {
+      color: green;
+    }
+  }
+
+  // Plain classes here stay global and are intentionally NOT module classes.
+  .globalOnly {
+    color: black;
+  }
+}

--- a/src/__tests__/noError/LocalInGlobalBlock/LocalInGlobalBlock.tsx
+++ b/src/__tests__/noError/LocalInGlobalBlock/LocalInGlobalBlock.tsx
@@ -1,0 +1,9 @@
+import styles from './LocalInGlobalBlock.module.scss';
+
+export const LocalInGlobalBlock: React.FC = () => (
+  <div className={styles.small}>
+    <div className={`${styles.medium} ${styles.active}`}>
+      <div className={styles.large} />
+    </div>
+  </div>
+);

--- a/src/__tests__/noError/noError.test.ts
+++ b/src/__tests__/noError/noError.test.ts
@@ -15,6 +15,7 @@ describe('Components without errors', () => {
     'GlobalClasses',
     'GlobalBlock',
     'LocalClasses',
+    'LocalInGlobalBlock',
     'Animations',
     'Complex',
     'Media',

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -654,4 +654,103 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual(sorted(['button', 'buttonBlack']));
     });
   });
+
+  describe(':local re-scoping inside a :global block (issue #101)', () => {
+    // A bare `:global {}` block scopes descendants globally, but a `:local(...)`
+    // function form (or a bare `:local` switch) nested inside it flips scope back
+    // to local. Those local classes must be extracted even though an ancestor
+    // opened a global block. Plain classes inside `:global` stay global.
+
+    test('single :local(...) inside a :global block is extracted', () => {
+      expect(
+        extractSorted(':global { :local(.small) { color: red; } }')
+      ).toEqual(sorted(['small']));
+    });
+
+    test('empty-bodied :local(...) inside a :global block is extracted', () => {
+      // The exact form from the issue report.
+      expect(extractSorted(':global { :local(.small) {} }')).toEqual(
+        sorted(['small'])
+      );
+    });
+
+    test('compound :local(...) inside a :global block is extracted', () => {
+      expect(
+        extractSorted(':global { :local(.root.active) { color: red; } }')
+      ).toEqual(sorted(['root', 'active']));
+    });
+
+    test('a plain class beside the :local(...) rule stays global', () => {
+      // `.g` is a plain class in global scope (dropped); `:local(.l)` re-scopes.
+      expect(
+        extractSorted(
+          ':global { .g { color: red; } :local(.l) { color: blue; } }'
+        )
+      ).toEqual(sorted(['l']));
+    });
+
+    test('a bare `:local` switch inside a :global block re-scopes descendants', () => {
+      expect(
+        extractSorted(':global { :local { .small { color: red; } } }')
+      ).toEqual(sorted(['small']));
+    });
+
+    test('a bare `:local .scoped` switch inside a :global block is local', () => {
+      expect(
+        extractSorted(':global { :local .scoped { color: red; } }')
+      ).toEqual(sorted(['scoped']));
+    });
+
+    test('nested rule under a bare `:local` switch inside :global stays local', () => {
+      expect(
+        extractSorted(':global { :local { .a { .b { color: red; } } } }')
+      ).toEqual(sorted(['a', 'b']));
+    });
+
+    test(':local(...) inside a `:global .scoped` switch is extracted', () => {
+      expect(
+        extractSorted(':global .scoped { :local(.deep) { color: red; } }')
+      ).toEqual(sorted(['deep']));
+    });
+
+    test(':local(...) under an at-rule inside a :global block is extracted', () => {
+      expect(
+        extractSorted(
+          ':global { @media (min-width: 1px) { :local(.m) { color: red; } } }'
+        )
+      ).toEqual(sorted(['m']));
+    });
+
+    test('a plain class nested one level under :local(...) inside :global stays global', () => {
+      // The `:local(.a)` FUNCTION form scopes only `.a`; it is not a bare switch,
+      // so its nested plain `.b` inherits the enclosing `:global` scope → global.
+      expect(
+        extractSorted(':global { :local(.a) { .b { color: red; } } }')
+      ).toEqual(sorted(['a']));
+    });
+
+    test('a nested :local(...) under a plain class inside :global is extracted', () => {
+      expect(
+        extractSorted(':global { .a { :local(.b) { color: red; } } }')
+      ).toEqual(sorted(['b']));
+    });
+
+    test('local class outside a :global block is unaffected by an inner :local', () => {
+      expect(
+        extractSorted('.outer { color: green; } :global { :local(.x) {} }')
+      ).toEqual(sorted(['outer', 'x']));
+    });
+
+    test('no regression: plain classes inside :global are still dropped', () => {
+      expect(
+        extractSorted(':global { .a { color: red; } .b { color: blue; } }')
+      ).toEqual([]);
+    });
+
+    test('double-dash modifier via :local(...) inside :global is extracted', () => {
+      expect(
+        extractSorted(':global { :local(.--variant) { color: red; } }')
+      ).toEqual(sorted(['--variant']));
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -792,5 +792,22 @@ describe('extractCssClasses (integration, real pipeline)', () => {
         sorted(['bar'])
       );
     });
+
+    test('inside a :global block, a leading plain compound stays global', () => {
+      // `.g` precedes the bare `:local` switch on the rule's own selector, so it
+      // inherits the enclosing `:global` scope and must NOT be extracted; only
+      // `.x` after the switch is local (Copilot review on PR #102).
+      expect(extractSorted(':global { .g :local .x { color: red; } }')).toEqual(
+        sorted(['x'])
+      );
+    });
+
+    test('a bare :local inside a :not() argument re-scopes it', () => {
+      // The rule inherits global scope; the bare `:local` inside `:not(...)`
+      // flips its argument back to local so `.x` is collected.
+      expect(
+        extractSorted(':global .a:not(:local .x) { color: red; }')
+      ).toEqual(sorted(['x']));
+    });
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.integration.test.ts
@@ -753,4 +753,44 @@ describe('extractCssClasses (integration, real pipeline)', () => {
       ).toEqual(sorted(['--variant']));
     });
   });
+
+  describe('both bare switches toggle scope within one selector chain', () => {
+    // `findClassNamesInSelector` toggles on `:global` AND `:local`; the last
+    // switch on the chain wins, so a `:local` after a `:global` resumes
+    // collecting (Copilot review on PR #102).
+
+    test('`:global :local .x` collects .x (last switch wins)', () => {
+      expect(extractSorted(':global :local .x { color: red; }')).toEqual(
+        sorted(['x'])
+      );
+    });
+
+    test('`:global .g :local .x` drops .g but keeps .x', () => {
+      expect(extractSorted(':global .g :local .x { color: red; }')).toEqual(
+        sorted(['x'])
+      );
+    });
+
+    test('`:local :global .x` drops .x (global is the last switch)', () => {
+      expect(extractSorted(':local :global .x { color: red; }')).toEqual([]);
+    });
+
+    test('a `:local` switch collects every compound after it', () => {
+      expect(extractSorted(':global :local .a .b { color: red; }')).toEqual(
+        sorted(['a', 'b'])
+      );
+    });
+
+    test('a bare `:local` switch resumes collection in a nested rule chain', () => {
+      expect(
+        extractSorted(':global { .g { :local .x { color: red; } } }')
+      ).toEqual(sorted(['x']));
+    });
+
+    test('no regression: `:global(.foo) .bar` keeps .bar (function form)', () => {
+      expect(extractSorted(':global(.foo) .bar { color: red; }')).toEqual(
+        sorted(['bar'])
+      );
+    });
+  });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
@@ -4,12 +4,8 @@ import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
 import {
   extractClassNamesFromAtRule,
   extractClassNamesFromRule,
-  extractLocalRescopedClassNamesFromRule,
 } from './utils/extractClassNamesFromRule.js';
-import {
-  isInsideGlobalScope,
-  selectorHasLocalSwitch,
-} from './utils/isInsideGlobalScope.js';
+import { isInsideGlobalScope } from './utils/isInsideGlobalScope.js';
 import { isSelectorBearingAtRule } from './utils/isSelectorBearingAtRule.js';
 
 export type CssClassInfo = {
@@ -21,18 +17,14 @@ export type CssClassInfo = {
 /**
  * The local class names a single rule defines, honoring CSS-Modules scope.
  *
- * A rule inside a bare `:global` block is global, so only classes flipped back
- * to local count: either the whole rule via a bare `:local` switch on its own
- * selector (`:local .x`), or an individual `:local(.foo)` function form. A rule
- * in local scope defines every class its selector names, as usual (issue #101).
+ * The rule's inherited scope (global when it sits inside a bare `:global {}`
+ * block) is passed as the extraction's starting scope; bare `:global`/`:local`
+ * switches within the rule's own selector then toggle it per compound, so a
+ * plain class stays global while a `:local` switch or `:local(...)` form flips
+ * back to local (issue #101).
  */
-const resolveRuleClassNames = (rule: Rule): string[] => {
-  if (isInsideGlobalScope(rule) && !selectorHasLocalSwitch(rule.selector)) {
-    return extractLocalRescopedClassNamesFromRule(rule);
-  }
-
-  return extractClassNamesFromRule(rule);
-};
+const resolveRuleClassNames = (rule: Rule): string[] =>
+  extractClassNamesFromRule(rule, isInsideGlobalScope(rule));
 
 export const extractCssClasses = (cssContent: string): string[] => {
   const { isFileIgnored, ignoredLines } = parseIgnoreComments(cssContent);

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/extractCssClasses.ts
@@ -1,16 +1,37 @@
+import type { Rule } from 'postcss';
 import postcssScss from 'postcss-scss';
 import { parseIgnoreComments } from '../../../../utils/parseIgnoreComments.js';
 import {
   extractClassNamesFromAtRule,
   extractClassNamesFromRule,
+  extractLocalRescopedClassNamesFromRule,
 } from './utils/extractClassNamesFromRule.js';
-import { isInsideGlobalScope } from './utils/isInsideGlobalScope.js';
+import {
+  isInsideGlobalScope,
+  selectorHasLocalSwitch,
+} from './utils/isInsideGlobalScope.js';
 import { isSelectorBearingAtRule } from './utils/isSelectorBearingAtRule.js';
 
 export type CssClassInfo = {
   className: string;
   line: number;
   column: number;
+};
+
+/**
+ * The local class names a single rule defines, honoring CSS-Modules scope.
+ *
+ * A rule inside a bare `:global` block is global, so only classes flipped back
+ * to local count: either the whole rule via a bare `:local` switch on its own
+ * selector (`:local .x`), or an individual `:local(.foo)` function form. A rule
+ * in local scope defines every class its selector names, as usual (issue #101).
+ */
+const resolveRuleClassNames = (rule: Rule): string[] => {
+  if (isInsideGlobalScope(rule) && !selectorHasLocalSwitch(rule.selector)) {
+    return extractLocalRescopedClassNamesFromRule(rule);
+  }
+
+  return extractClassNamesFromRule(rule);
 };
 
 export const extractCssClasses = (cssContent: string): string[] => {
@@ -29,12 +50,7 @@ export const extractCssClasses = (cssContent: string): string[] => {
       return;
     }
 
-    // Classes inside a bare `:global { … }` block/switch are global, not local.
-    if (isInsideGlobalScope(rule)) {
-      return;
-    }
-
-    const ruleClassNames = extractClassNamesFromRule(rule);
+    const ruleClassNames = resolveRuleClassNames(rule);
     for (const className of ruleClassNames) {
       classNames.add(className);
     }
@@ -79,12 +95,7 @@ export const extractCssClassesWithLocations = (
       return;
     }
 
-    // Classes inside a bare `:global { … }` block/switch are global, not local.
-    if (isInsideGlobalScope(rule)) {
-      return;
-    }
-
-    const ruleClassNames = extractClassNamesFromRule(rule);
+    const ruleClassNames = resolveRuleClassNames(rule);
     for (const className of ruleClassNames) {
       // Only keep the first occurrence of each class
       if (!classInfoMap.has(className) && rule.source?.start) {

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -1,10 +1,6 @@
-import type { AstSelector } from 'css-selector-parser';
 import type { AtRule, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
-import {
-  findClassNamesInSelector,
-  findLocalRescopedClassNames,
-} from './findClassNamesInSelector.js';
+import { findClassNamesInSelector } from './findClassNamesInSelector.js';
 import {
   getParentClassName,
   resolveAmpersandSelector,
@@ -12,63 +8,44 @@ import {
 import { parseSelector } from './selectorParser.js';
 
 /**
- * Parse a raw selector string (already ampersand-resolved against its parent)
- * and reduce it to class names with `collect`. Returns an empty array if the
- * selector cannot be parsed at all.
+ * Resolve a raw selector string (already ampersand-resolved against its parent)
+ * into the class names it defines. `initialScope` is the scope the selector
+ * starts in, inherited from its ancestors — `true` (global) for a rule inside a
+ * bare `:global {}` block (issue #101). Returns an empty array if the selector
+ * cannot be parsed at all.
  */
-const extractWith = (
+export const extractClassNamesFromSelector = (
   selector: string,
-  collect: (parsed: AstSelector) => string[]
+  initialScope = false
 ): string[] => {
   try {
     const processedSelector = clearGlobalSelectors(selector);
     const parsed = parseSelector(processedSelector);
 
     if (Array.isArray(parsed)) {
-      return parsed.flatMap(collect);
+      return parsed.flatMap((s) => findClassNamesInSelector(s, initialScope));
     }
 
-    return collect(parsed);
+    return findClassNamesInSelector(parsed, initialScope);
   } catch {
     return [];
   }
 };
 
 /**
- * Resolve a raw selector string into the class names it defines. Returns an
- * empty array if the selector cannot be parsed at all.
+ * Resolve a rule into the local class names it defines. `initialScope` is the
+ * scope inherited from the rule's ancestors — `true` when it sits inside a bare
+ * `:global {}` block, so its plain classes are global and only ones a `:local`
+ * switch/`:local(...)` form flips back count (issue #101).
  */
-export const extractClassNamesFromSelector = (selector: string): string[] =>
-  extractWith(selector, findClassNamesInSelector);
-
-/**
- * Resolve a raw selector string into ONLY the classes it re-scopes to local via
- * a `:local(...)` function form. For rules whose inherited scope is global
- * (inside a bare `:global` block): plain classes there are global, but a
- * `:local(.foo)` form flips `.foo` back to local (issue #101).
- */
-export const extractLocalRescopedClassNamesFromSelector = (
-  selector: string
-): string[] => extractWith(selector, findLocalRescopedClassNames);
-
-export const extractClassNamesFromRule = (rule: Rule): string[] => {
-  const parentClassName = getParentClassName(rule);
-  const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
-
-  return extractClassNamesFromSelector(resolved);
-};
-
-/**
- * Like {@link extractClassNamesFromRule} but for a rule whose inherited scope is
- * global: only `:local(...)`-re-scoped classes are returned (issue #101).
- */
-export const extractLocalRescopedClassNamesFromRule = (
-  rule: Rule
+export const extractClassNamesFromRule = (
+  rule: Rule,
+  initialScope = false
 ): string[] => {
   const parentClassName = getParentClassName(rule);
   const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
 
-  return extractLocalRescopedClassNamesFromSelector(resolved);
+  return extractClassNamesFromSelector(resolved, initialScope);
 };
 
 /**

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/extractClassNamesFromRule.ts
@@ -1,6 +1,10 @@
+import type { AstSelector } from 'css-selector-parser';
 import type { AtRule, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
-import { findClassNamesInSelector } from './findClassNamesInSelector.js';
+import {
+  findClassNamesInSelector,
+  findLocalRescopedClassNames,
+} from './findClassNamesInSelector.js';
 import {
   getParentClassName,
   resolveAmpersandSelector,
@@ -8,30 +12,63 @@ import {
 import { parseSelector } from './selectorParser.js';
 
 /**
- * Resolve a raw selector string (already ampersand-resolved against its parent)
- * into the class names it defines. Returns an empty array if the selector
- * cannot be parsed at all.
+ * Parse a raw selector string (already ampersand-resolved against its parent)
+ * and reduce it to class names with `collect`. Returns an empty array if the
+ * selector cannot be parsed at all.
  */
-export const extractClassNamesFromSelector = (selector: string): string[] => {
+const extractWith = (
+  selector: string,
+  collect: (parsed: AstSelector) => string[]
+): string[] => {
   try {
     const processedSelector = clearGlobalSelectors(selector);
     const parsed = parseSelector(processedSelector);
 
     if (Array.isArray(parsed)) {
-      return parsed.flatMap(findClassNamesInSelector);
+      return parsed.flatMap(collect);
     }
 
-    return findClassNamesInSelector(parsed);
+    return collect(parsed);
   } catch {
     return [];
   }
 };
+
+/**
+ * Resolve a raw selector string into the class names it defines. Returns an
+ * empty array if the selector cannot be parsed at all.
+ */
+export const extractClassNamesFromSelector = (selector: string): string[] =>
+  extractWith(selector, findClassNamesInSelector);
+
+/**
+ * Resolve a raw selector string into ONLY the classes it re-scopes to local via
+ * a `:local(...)` function form. For rules whose inherited scope is global
+ * (inside a bare `:global` block): plain classes there are global, but a
+ * `:local(.foo)` form flips `.foo` back to local (issue #101).
+ */
+export const extractLocalRescopedClassNamesFromSelector = (
+  selector: string
+): string[] => extractWith(selector, findLocalRescopedClassNames);
 
 export const extractClassNamesFromRule = (rule: Rule): string[] => {
   const parentClassName = getParentClassName(rule);
   const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
 
   return extractClassNamesFromSelector(resolved);
+};
+
+/**
+ * Like {@link extractClassNamesFromRule} but for a rule whose inherited scope is
+ * global: only `:local(...)`-re-scoped classes are returned (issue #101).
+ */
+export const extractLocalRescopedClassNamesFromRule = (
+  rule: Rule
+): string[] => {
+  const parentClassName = getParentClassName(rule);
+  const resolved = resolveAmpersandSelector(rule.selector, parentClassName);
+
+  return extractLocalRescopedClassNamesFromSelector(resolved);
 };
 
 /**

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
@@ -350,6 +350,30 @@ describe('findClassNamesInSelector', () => {
     });
   });
 
+  describe('toggles scope on both bare switches (nearest wins)', () => {
+    // A bare `:local` after a bare `:global` in the same chain resumes
+    // collecting; the last switch wins (Copilot review on PR #102).
+    test('resumes collecting after a `:local` following a `:global`', () => {
+      const selector = globalAwareParser(':global :local .x');
+      expect(findClassNamesInSelector(selector)).toEqual(['x']);
+    });
+
+    test('drops the middle global compound, keeps the trailing local one', () => {
+      const selector = globalAwareParser(':global .g :local .x');
+      expect(findClassNamesInSelector(selector)).toEqual(['x']);
+    });
+
+    test('a `:global` following a `:local` drops the rest', () => {
+      const selector = globalAwareParser(':local :global .x');
+      expect(findClassNamesInSelector(selector)).toEqual([]);
+    });
+
+    test('collects every compound after a `:local` switch', () => {
+      const selector = globalAwareParser(':global :local .a .b');
+      expect(findClassNamesInSelector(selector)).toEqual(['a', 'b']);
+    });
+  });
+
   describe('should collect classes inside the :local(...) function form (issue #97)', () => {
     // The function form `:local(.foo)` parses its argument as a String; those
     // inner classes are explicitly local and must be collected.

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import type { AstSelector, Parser } from 'css-selector-parser';
 import { createParser } from 'css-selector-parser';
-import { findClassNamesInSelector } from './findClassNamesInSelector.js';
+import {
+  findClassNamesInSelector,
+  findLocalRescopedClassNames,
+} from './findClassNamesInSelector.js';
 import { parseSelector as globalAwareParser } from './selectorParser.js';
 
 const parseSelector: Parser = createParser();
@@ -374,5 +377,47 @@ describe('findClassNamesInSelector', () => {
       const selector = globalAwareParser(':local(.--reversed)');
       expect(findClassNamesInSelector(selector)).toEqual(['--reversed']);
     });
+  });
+});
+
+describe('findLocalRescopedClassNames', () => {
+  // Used only for rules whose inherited scope is global: plain classes there are
+  // global and must be dropped, but a `:local(...)` function form re-scopes its
+  // inner classes back to local (issue #101).
+
+  test('collects the inner class of a :local(...) function form', () => {
+    const selector = globalAwareParser(':local(.small)');
+    expect(findLocalRescopedClassNames(selector)).toEqual(['small']);
+  });
+
+  test('collects every compound inside :local(...)', () => {
+    const selector = globalAwareParser(':local(.root.active)');
+    expect(findLocalRescopedClassNames(selector)).toEqual(['root', 'active']);
+  });
+
+  test('drops a plain class that is not wrapped in :local(...)', () => {
+    const selector = globalAwareParser('.plain');
+    expect(findLocalRescopedClassNames(selector)).toEqual([]);
+  });
+
+  test('keeps only the :local(...) part of a mixed selector', () => {
+    // `.plain` is global here; only `.kept` is re-scoped to local.
+    const selector = globalAwareParser('.plain :local(.kept)');
+    expect(findLocalRescopedClassNames(selector)).toEqual(['kept']);
+  });
+
+  test('ignores a :global(...) function form', () => {
+    const selector = globalAwareParser(':global(.g) :local(.l)');
+    expect(findLocalRescopedClassNames(selector)).toEqual(['l']);
+  });
+
+  test('finds a :local(...) nested inside a pseudo-class argument', () => {
+    const selector = globalAwareParser(':not(:local(.x))');
+    expect(findLocalRescopedClassNames(selector)).toEqual(['x']);
+  });
+
+  test('returns nothing for a selector with no :local(...) form', () => {
+    const selector = globalAwareParser('div > .a .b');
+    expect(findLocalRescopedClassNames(selector)).toEqual([]);
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { AstSelector, Parser } from 'css-selector-parser';
 import { createParser } from 'css-selector-parser';
-import {
-  findClassNamesInSelector,
-  findLocalRescopedClassNames,
-} from './findClassNamesInSelector.js';
+import { findClassNamesInSelector } from './findClassNamesInSelector.js';
 import { parseSelector as globalAwareParser } from './selectorParser.js';
 
 const parseSelector: Parser = createParser();
@@ -404,44 +401,60 @@ describe('findClassNamesInSelector', () => {
   });
 });
 
-describe('findLocalRescopedClassNames', () => {
-  // Used only for rules whose inherited scope is global: plain classes there are
-  // global and must be dropped, but a `:local(...)` function form re-scopes its
-  // inner classes back to local (issue #101).
+describe('with an inherited global initialScope (issue #101)', () => {
+  // A rule inside a bare `:global {}` block starts extraction in global scope:
+  // plain classes are global and dropped, but a `:local(...)` form or a bare
+  // `:local` switch flips (part of) the selector back to local.
 
   test('collects the inner class of a :local(...) function form', () => {
     const selector = globalAwareParser(':local(.small)');
-    expect(findLocalRescopedClassNames(selector)).toEqual(['small']);
+    expect(findClassNamesInSelector(selector, true)).toEqual(['small']);
   });
 
   test('collects every compound inside :local(...)', () => {
     const selector = globalAwareParser(':local(.root.active)');
-    expect(findLocalRescopedClassNames(selector)).toEqual(['root', 'active']);
+    expect(findClassNamesInSelector(selector, true)).toEqual([
+      'root',
+      'active',
+    ]);
   });
 
-  test('drops a plain class that is not wrapped in :local(...)', () => {
+  test('drops a plain class that is not re-scoped to local', () => {
     const selector = globalAwareParser('.plain');
-    expect(findLocalRescopedClassNames(selector)).toEqual([]);
+    expect(findClassNamesInSelector(selector, true)).toEqual([]);
   });
 
   test('keeps only the :local(...) part of a mixed selector', () => {
     // `.plain` is global here; only `.kept` is re-scoped to local.
     const selector = globalAwareParser('.plain :local(.kept)');
-    expect(findLocalRescopedClassNames(selector)).toEqual(['kept']);
+    expect(findClassNamesInSelector(selector, true)).toEqual(['kept']);
   });
 
   test('ignores a :global(...) function form', () => {
     const selector = globalAwareParser(':global(.g) :local(.l)');
-    expect(findLocalRescopedClassNames(selector)).toEqual(['l']);
+    expect(findClassNamesInSelector(selector, true)).toEqual(['l']);
   });
 
   test('finds a :local(...) nested inside a pseudo-class argument', () => {
     const selector = globalAwareParser(':not(:local(.x))');
-    expect(findLocalRescopedClassNames(selector)).toEqual(['x']);
+    expect(findClassNamesInSelector(selector, true)).toEqual(['x']);
   });
 
-  test('returns nothing for a selector with no :local(...) form', () => {
+  test('a bare `:local` switch flips the rest of the selector back to local', () => {
+    // `.g` stays global (dropped); `.x` after the bare `:local` switch is local.
+    const selector = globalAwareParser('.g :local .x');
+    expect(findClassNamesInSelector(selector, true)).toEqual(['x']);
+  });
+
+  test('a bare `:local` inside a pseudo-class argument re-scopes it', () => {
+    // The current global scope is carried into `:not(...)`; the bare `:local`
+    // inside flips it, so `.x` is collected (Copilot review on PR #102).
+    const selector = globalAwareParser(':not(:local .x)');
+    expect(findClassNamesInSelector(selector, true)).toEqual(['x']);
+  });
+
+  test('returns nothing for an all-global selector', () => {
     const selector = globalAwareParser('div > .a .b');
-    expect(findLocalRescopedClassNames(selector)).toEqual([]);
+    expect(findClassNamesInSelector(selector, true)).toEqual([]);
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -16,6 +16,57 @@ export const findClassNamesInLocalArgument = (argument: string): string[] => {
   }
 };
 
+/**
+ * Collect ONLY the classes explicitly re-scoped to local via a `:local(...)`
+ * function form. Used for rules whose inherited scope is global (they sit inside
+ * a bare `:global` block): plain classes there are global and must be dropped,
+ * but a `:local(.foo)` form flips `.foo` back to local (issue #101).
+ *
+ * A bare `:local` switch is NOT handled here — it flips the whole rule back to
+ * local scope, which `isInsideGlobalScope` already reflects, so such rules go
+ * through the normal `findClassNamesInSelector` path instead.
+ */
+export const findLocalRescopedClassNames = (
+  selector: AstSelector
+): string[] => {
+  if (!selector.rules.length) {
+    return [];
+  }
+
+  const classNames: string[] = [];
+
+  const collectFromRule = (rule: AstRule): void => {
+    for (const item of rule.items) {
+      if (
+        item.type === 'PseudoClass' &&
+        item.name === 'local' &&
+        item.argument &&
+        item.argument.type === 'String'
+      ) {
+        classNames.push(...findClassNamesInLocalArgument(item.argument.value));
+      } else if (
+        item.type === 'PseudoClass' &&
+        item.argument &&
+        item.argument.type === 'Selector'
+      ) {
+        // Recurse into pseudo-class selector arguments (e.g. `:not(:local(.x))`)
+        // so a nested :local form is still found.
+        classNames.push(...findLocalRescopedClassNames(item.argument));
+      }
+    }
+
+    if (rule.nestedRule) {
+      collectFromRule(rule.nestedRule);
+    }
+  };
+
+  for (const rule of selector.rules) {
+    collectFromRule(rule);
+  }
+
+  return classNames;
+};
+
 export const findClassNamesInSelector = (selector: AstSelector): string[] => {
   if (!selector.rules.length) {
     return [];

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -1,5 +1,9 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
-import { isGlobalSwitchItem, parseSelector } from './selectorParser.js';
+import {
+  isGlobalSwitchItem,
+  isLocalSwitchItem,
+  parseSelector,
+} from './selectorParser.js';
 
 /**
  * The CSS-Modules `:local(...)` function form marks its inner classes as local,
@@ -24,7 +28,8 @@ export const findClassNamesInLocalArgument = (argument: string): string[] => {
  *
  * A bare `:local` switch is NOT handled here — it flips the whole rule back to
  * local scope, which `isInsideGlobalScope` already reflects, so such rules go
- * through the normal `findClassNamesInSelector` path instead.
+ * through the full `findClassNamesInSelector` path (which itself toggles on both
+ * `:global` and `:local` switches within the selector chain) instead.
  */
 export const findLocalRescopedClassNames = (
   selector: AstSelector
@@ -74,18 +79,33 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
 
   const classNames: string[] = [];
 
-  const extractClassNamesFromRule = (rule: AstRule): void => {
+  // A bare `:global`/`:local` switch toggles the scope of every compound to its
+  // right — in this selector AND its nested rules — and the nearest (last) one
+  // wins (`:global :local .x` is local). While in global scope plain classes are
+  // dropped; a later bare `:local` resumes collection. The function forms
+  // `:global(.foo)`/`:local(.foo)` are NOT switches and never change `isGlobal`.
+  // `isGlobal` is threaded through `rule.nestedRule` so the chain carries state.
+  const extractClassNamesFromRule = (
+    rule: AstRule,
+    isGlobal: boolean
+  ): void => {
+    let global = isGlobal;
+
     for (const item of rule.items) {
-      // A bare `:global` switch makes every compound to its right — in this
-      // selector and in its nested rules — global, so stop collecting this
-      // branch. (The function form `:global(.foo)` is not a switch; its inner
-      // class is simply not collected, while `:global(.foo) .bar` keeps `.bar`.)
       if (isGlobalSwitchItem(item)) {
-        return;
+        global = true;
+        continue;
+      }
+      if (isLocalSwitchItem(item)) {
+        global = false;
+        continue;
       }
 
       if (item.type === 'ClassName') {
-        classNames.push(item.name);
+        // Plain classes are local only outside a bare `:global` switch.
+        if (!global) {
+          classNames.push(item.name);
+        }
       } else if (
         item.type === 'PseudoClass' &&
         item.name === 'local' &&
@@ -93,27 +113,33 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
         item.argument.type === 'String'
       ) {
         // The `:local(.foo)` function form scopes its inner classes as local
-        // (issue #97). The parser captures the argument as a raw String, so
-        // re-parse it to collect the classes. `:global(.foo)` keeps the opposite
-        // behavior: its String argument is intentionally left uncollected.
+        // (issue #97) regardless of the surrounding switch. The parser captures
+        // the argument as a raw String, so re-parse it to collect the classes.
+        // `:global(.foo)` keeps the opposite behavior: its String argument is
+        // intentionally left uncollected.
         classNames.push(...findClassNamesInLocalArgument(item.argument.value));
       } else if (
         item.type === 'PseudoClass' &&
         item.argument &&
         item.argument.type === 'Selector'
       ) {
-        // Extract class names from pseudo-class arguments like :not(.class)
-        classNames.push(...findClassNamesInSelector(item.argument));
+        // Extract class names from pseudo-class arguments like :not(.class),
+        // carrying the current switch scope into the argument.
+        classNames.push(
+          ...(global
+            ? findLocalRescopedClassNames(item.argument)
+            : findClassNamesInSelector(item.argument))
+        );
       }
     }
 
     if (rule.nestedRule) {
-      extractClassNamesFromRule(rule.nestedRule);
+      extractClassNamesFromRule(rule.nestedRule, global);
     }
   };
 
   for (const rule of selector.rules) {
-    extractClassNamesFromRule(rule);
+    extractClassNamesFromRule(rule, false);
   }
 
   return classNames;

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/findClassNamesInSelector.ts
@@ -21,18 +21,25 @@ export const findClassNamesInLocalArgument = (argument: string): string[] => {
 };
 
 /**
- * Collect ONLY the classes explicitly re-scoped to local via a `:local(...)`
- * function form. Used for rules whose inherited scope is global (they sit inside
- * a bare `:global` block): plain classes there are global and must be dropped,
- * but a `:local(.foo)` form flips `.foo` back to local (issue #101).
+ * Collect the local class names a selector defines.
  *
- * A bare `:local` switch is NOT handled here — it flips the whole rule back to
- * local scope, which `isInsideGlobalScope` already reflects, so such rules go
- * through the full `findClassNamesInSelector` path (which itself toggles on both
- * `:global` and `:local` switches within the selector chain) instead.
+ * `initialScope` is the scope the selector starts in, inherited from its
+ * ancestors: `false` (local) at the top level, `true` (global) for a rule nested
+ * inside a bare `:global {}` block (issue #101). Within the selector a bare
+ * `:global`/`:local` switch toggles the scope of every compound to its right —
+ * in this selector AND its nested rules — and the nearest (last) switch wins
+ * (`:global :local .x` is local, `:local :global .x` is global). Plain class
+ * tokens are collected only while in local scope.
+ *
+ * The function forms `:global(.foo)`/`:local(.foo)` are NOT switches: they never
+ * change the running scope. `:local(.foo)` always collects its inner classes as
+ * local regardless of scope (issue #97); `:global(.foo)` never collects its
+ * argument. The scope is threaded through `rule.nestedRule` and into pseudo-class
+ * selector arguments (`:not(...)`) so the whole chain shares one running state.
  */
-export const findLocalRescopedClassNames = (
-  selector: AstSelector
+export const findClassNamesInSelector = (
+  selector: AstSelector,
+  initialScope = false
 ): string[] => {
   if (!selector.rules.length) {
     return [];
@@ -40,51 +47,6 @@ export const findLocalRescopedClassNames = (
 
   const classNames: string[] = [];
 
-  const collectFromRule = (rule: AstRule): void => {
-    for (const item of rule.items) {
-      if (
-        item.type === 'PseudoClass' &&
-        item.name === 'local' &&
-        item.argument &&
-        item.argument.type === 'String'
-      ) {
-        classNames.push(...findClassNamesInLocalArgument(item.argument.value));
-      } else if (
-        item.type === 'PseudoClass' &&
-        item.argument &&
-        item.argument.type === 'Selector'
-      ) {
-        // Recurse into pseudo-class selector arguments (e.g. `:not(:local(.x))`)
-        // so a nested :local form is still found.
-        classNames.push(...findLocalRescopedClassNames(item.argument));
-      }
-    }
-
-    if (rule.nestedRule) {
-      collectFromRule(rule.nestedRule);
-    }
-  };
-
-  for (const rule of selector.rules) {
-    collectFromRule(rule);
-  }
-
-  return classNames;
-};
-
-export const findClassNamesInSelector = (selector: AstSelector): string[] => {
-  if (!selector.rules.length) {
-    return [];
-  }
-
-  const classNames: string[] = [];
-
-  // A bare `:global`/`:local` switch toggles the scope of every compound to its
-  // right — in this selector AND its nested rules — and the nearest (last) one
-  // wins (`:global :local .x` is local). While in global scope plain classes are
-  // dropped; a later bare `:local` resumes collection. The function forms
-  // `:global(.foo)`/`:local(.foo)` are NOT switches and never change `isGlobal`.
-  // `isGlobal` is threaded through `rule.nestedRule` so the chain carries state.
   const extractClassNamesFromRule = (
     rule: AstRule,
     isGlobal: boolean
@@ -125,11 +87,7 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
       ) {
         // Extract class names from pseudo-class arguments like :not(.class),
         // carrying the current switch scope into the argument.
-        classNames.push(
-          ...(global
-            ? findLocalRescopedClassNames(item.argument)
-            : findClassNamesInSelector(item.argument))
-        );
+        classNames.push(...findClassNamesInSelector(item.argument, global));
       }
     }
 
@@ -139,7 +97,7 @@ export const findClassNamesInSelector = (selector: AstSelector): string[] => {
   };
 
   for (const rule of selector.rules) {
-    extractClassNamesFromRule(rule, false);
+    extractClassNamesFromRule(rule, initialScope);
   }
 
   return classNames;

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { Rule } from 'postcss';
 import postcssScss from 'postcss-scss';
-import {
-  isInsideGlobalScope,
-  selectorHasLocalSwitch,
-} from './isInsideGlobalScope.js';
+import { isInsideGlobalScope } from './isInsideGlobalScope.js';
 
 /** Parse SCSS and return the first rule whose selector matches `selector`. */
 const ruleBySelector = (css: string, selector: string): Rule => {
@@ -106,35 +103,5 @@ describe('isInsideGlobalScope', () => {
       const rule = ruleBySelector(':global { :local(.a) { .b {} } }', '.b');
       expect(isInsideGlobalScope(rule)).toBe(true);
     });
-  });
-});
-
-describe('selectorHasLocalSwitch', () => {
-  test('bare `:local` switch is detected', () => {
-    expect(selectorHasLocalSwitch(':local .scoped')).toBe(true);
-  });
-
-  test('bare `:local {}` block selector is detected', () => {
-    expect(selectorHasLocalSwitch(':local')).toBe(true);
-  });
-
-  test('the `:local(.foo)` function form is NOT a switch', () => {
-    expect(selectorHasLocalSwitch(':local(.foo)')).toBe(false);
-  });
-
-  test('a plain selector has no local switch', () => {
-    expect(selectorHasLocalSwitch('.foo .bar')).toBe(false);
-  });
-
-  test('a bare `:global` switch is not a local switch', () => {
-    expect(selectorHasLocalSwitch(':global .foo')).toBe(false);
-  });
-
-  test('the last switch wins: `:global :local` is a local switch', () => {
-    expect(selectorHasLocalSwitch(':global :local .x')).toBe(true);
-  });
-
-  test('the last switch wins: `:local :global` is not a local switch', () => {
-    expect(selectorHasLocalSwitch(':local :global .x')).toBe(false);
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import type { Rule } from 'postcss';
 import postcssScss from 'postcss-scss';
-import { isInsideGlobalScope } from './isInsideGlobalScope.js';
+import {
+  isInsideGlobalScope,
+  selectorHasLocalSwitch,
+} from './isInsideGlobalScope.js';
 
 /** Parse SCSS and return the first rule whose selector matches `selector`. */
 const ruleBySelector = (css: string, selector: string): Rule => {
@@ -79,5 +82,59 @@ describe('isInsideGlobalScope', () => {
   test('a rule under an at-rule but NOT inside any `:global` switch is not in global scope', () => {
     const rule = ruleBySelector('@media screen { .local {} }', '.local');
     expect(isInsideGlobalScope(rule)).toBe(false);
+  });
+
+  describe('a bare `:local` switch flips scope back (issue #101)', () => {
+    test('a bare `:local {}` block inside `:global {}` is not global', () => {
+      const rule = ruleBySelector(':global { :local { .x {} } }', '.x');
+      expect(isInsideGlobalScope(rule)).toBe(false);
+    });
+
+    test('the nearest switch wins: `:local` closer than `:global`', () => {
+      const rule = ruleBySelector(':global { :local { .a { .b {} } } }', '.b');
+      expect(isInsideGlobalScope(rule)).toBe(false);
+    });
+
+    test('the nearest switch wins: `:global` closer than `:local`', () => {
+      const rule = ruleBySelector(':local { :global { .a { .b {} } } }', '.b');
+      expect(isInsideGlobalScope(rule)).toBe(true);
+    });
+
+    test('a `:local(...)` FUNCTION form ancestor does not flip scope', () => {
+      // `:local(.a)` scopes only `.a`; its plain descendant `.b` inherits the
+      // enclosing `:global` scope.
+      const rule = ruleBySelector(':global { :local(.a) { .b {} } }', '.b');
+      expect(isInsideGlobalScope(rule)).toBe(true);
+    });
+  });
+});
+
+describe('selectorHasLocalSwitch', () => {
+  test('bare `:local` switch is detected', () => {
+    expect(selectorHasLocalSwitch(':local .scoped')).toBe(true);
+  });
+
+  test('bare `:local {}` block selector is detected', () => {
+    expect(selectorHasLocalSwitch(':local')).toBe(true);
+  });
+
+  test('the `:local(.foo)` function form is NOT a switch', () => {
+    expect(selectorHasLocalSwitch(':local(.foo)')).toBe(false);
+  });
+
+  test('a plain selector has no local switch', () => {
+    expect(selectorHasLocalSwitch('.foo .bar')).toBe(false);
+  });
+
+  test('a bare `:global` switch is not a local switch', () => {
+    expect(selectorHasLocalSwitch(':global .foo')).toBe(false);
+  });
+
+  test('the last switch wins: `:global :local` is a local switch', () => {
+    expect(selectorHasLocalSwitch(':global :local .x')).toBe(true);
+  });
+
+  test('the last switch wins: `:local :global` is not a local switch', () => {
+    expect(selectorHasLocalSwitch(':local :global .x')).toBe(false);
   });
 });

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
@@ -109,15 +109,3 @@ export const isInsideGlobalScope = (rule: Rule): boolean => {
 
   return false;
 };
-
-/**
- * Does a rule's OWN selector open a bare `:local` switch that governs its whole
- * body (`:local { … }`, `:local .scoped { … }`)? Such a rule re-scopes back to
- * local even when nested in a `:global` block, so its classes are extracted in
- * full rather than only its `:local(...)` function forms (issue #101).
- *
- * The function form `:local(.foo)` is NOT a switch and returns `false` here —
- * only `.foo` is re-scoped, handled per-class elsewhere.
- */
-export const selectorHasLocalSwitch = (selector: string): boolean =>
-  selectorSwitchScope(selector) === 'local';

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/isInsideGlobalScope.ts
@@ -1,40 +1,93 @@
 import type { AstRule, AstSelector } from 'css-selector-parser';
 import type { Container, Document, Rule } from 'postcss';
 import { clearGlobalSelectors } from './clearGlobalSelectors.js';
-import { isGlobalSwitchItem, parseSelector } from './selectorParser.js';
-
-const ruleHasGlobalSwitch = (rule: AstRule): boolean =>
-  rule.items.some(isGlobalSwitchItem) ||
-  (rule.nestedRule ? ruleHasGlobalSwitch(rule.nestedRule) : false);
+import {
+  isGlobalSwitchItem,
+  isLocalSwitchItem,
+  parseSelector,
+} from './selectorParser.js';
 
 /**
- * Does this selector string contain a bare `:global` scope SWITCH at any point?
- * The bare form turns every nested rule's classes global, so a rule with such
- * an ancestor defines global (not local) classes.
+ * The bare-switch scope a single selector opens for its nested rules, or `null`
+ * when it opens none. `:global`/`:local` (no argument) are switches; the
+ * function forms `:global(.foo)`/`:local(.foo)` are not.
  */
-const selectorHasGlobalSwitch = (selector: string): boolean => {
-  // Cheap reject for the common case (no `:global` at all) — avoids a parser
-  // allocation on every ancestor of every rule in `:global`-free stylesheets.
-  if (!selector.includes(':global')) {
-    return false;
+type SwitchScope = 'global' | 'local' | null;
+
+/**
+ * The last bare switch in a parsed rule chain wins (SCSS concatenates nested
+ * rules left to right, so a later switch overrides an earlier one on the same
+ * chain, e.g. `:global :local .x` is local). Returns `null` if the chain has
+ * no bare switch at all.
+ */
+const ruleSwitchScope = (rule: AstRule): SwitchScope => {
+  let scope: SwitchScope = null;
+
+  for (const item of rule.items) {
+    if (isGlobalSwitchItem(item)) {
+      scope = 'global';
+    } else if (isLocalSwitchItem(item)) {
+      scope = 'local';
+    }
+  }
+
+  if (rule.nestedRule) {
+    const nested = ruleSwitchScope(rule.nestedRule);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  return scope;
+};
+
+/**
+ * The bare `:global`/`:local` scope SWITCH a selector string opens, or `null`
+ * when it opens none. The bare form turns every nested rule's classes global
+ * (or back to local), so a rule inherits the scope of its nearest switching
+ * ancestor. The function forms `:global(.foo)`/`:local(.foo)` are NOT switches.
+ */
+const selectorSwitchScope = (selector: string): SwitchScope => {
+  // Cheap reject for the common case (no switch keyword at all) — avoids a
+  // parser allocation on every ancestor of every rule in switch-free sheets.
+  if (!selector.includes(':global') && !selector.includes(':local')) {
+    return null;
   }
 
   let parsed: AstSelector;
   try {
     parsed = parseSelector(clearGlobalSelectors(selector));
   } catch {
-    return false;
+    return null;
   }
 
-  return parsed.rules.some(ruleHasGlobalSwitch);
+  // Across a selector list (`:global .a, :local .b`) the members can disagree;
+  // there is no single scope. This mainly matters for the single-member ancestor
+  // selectors we test — take the last SWITCH-BEARING member as the effective one
+  // (members with no switch, e.g. the `.b` in `:global .a, .b`, leave it as is).
+  let scope: SwitchScope = null;
+  for (const rule of parsed.rules) {
+    const ruleScope = ruleSwitchScope(rule);
+    if (ruleScope !== null) {
+      scope = ruleScope;
+    }
+  }
+
+  return scope;
 };
 
 /**
- * A rule lives in global scope when any ancestor rule opens a bare `:global`
- * block/switch (e.g. `:global { .foo {} }` or `:global .scoped { .deep {} }`).
- * SCSS nesting concatenates the child selector to the right of the switch, so
- * the child is global too. The function form `:global(.foo) { .bar {} }` does
- * NOT count — `.bar` stays local — which `selectorHasGlobalSwitch` reflects.
+ * A rule lives in global scope when its nearest scope-switching ancestor opens a
+ * bare `:global` block/switch (e.g. `:global { .foo {} }` or `:global .scoped {
+ * .deep {} }`) and no closer `:local` switch flips it back. SCSS nesting
+ * concatenates the child selector to the right of the switch, so the child
+ * inherits that scope.
+ *
+ * The nearest switch wins: `:global { :local { .x {} } }` puts `.x` back in
+ * local scope. The function forms `:global(.foo)` / `:local(.foo)` are NOT
+ * switches — `:global(.foo) { .bar {} }` leaves `.bar` local (issue #91), and a
+ * `:local(.foo)` FUNCTION form nested in a `:global` block re-scopes only `.foo`,
+ * not its plain-class descendants (issue #101, handled in `extractCssClasses`).
  *
  * At-rules between the switch and the class (`:global { @media … { .g {} } }`)
  * are walked through, not stopped at: only `rule` ancestors carry a selector to
@@ -45,14 +98,26 @@ export const isInsideGlobalScope = (rule: Rule): boolean => {
   let parent: Container | Document | undefined = rule.parent;
 
   while (parent) {
-    if (
-      parent.type === 'rule' &&
-      selectorHasGlobalSwitch((parent as Rule).selector)
-    ) {
-      return true;
+    if (parent.type === 'rule') {
+      const scope = selectorSwitchScope((parent as Rule).selector);
+      if (scope !== null) {
+        return scope === 'global';
+      }
     }
     parent = parent.parent;
   }
 
   return false;
 };
+
+/**
+ * Does a rule's OWN selector open a bare `:local` switch that governs its whole
+ * body (`:local { … }`, `:local .scoped { … }`)? Such a rule re-scopes back to
+ * local even when nested in a `:global` block, so its classes are extracted in
+ * full rather than only its `:local(...)` function forms (issue #101).
+ *
+ * The function form `:local(.foo)` is NOT a switch and returns `false` here —
+ * only `.foo` is re-scoped, handled per-class elsewhere.
+ */
+export const selectorHasLocalSwitch = (selector: string): boolean =>
+  selectorSwitchScope(selector) === 'local';

--- a/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
+++ b/src/lib/getUnusedClassesFromCss/utils/extractCssClasses/utils/selectorParser.ts
@@ -33,3 +33,13 @@ export const parseSelector: Parser = createParser({
  */
 export const isGlobalSwitchItem = (item: AstRuleItem): boolean =>
   item.type === 'PseudoClass' && item.name === 'global' && !item.argument;
+
+/**
+ * The mirror of {@link isGlobalSwitchItem}: a bare `:local` (no argument) is a
+ * scope SWITCH back to local. Nested inside a `:global` block it re-scopes every
+ * compound to its right — in this selector and its nested rules — as local
+ * (issue #101). The function form `:local(.foo)` carries an argument and is NOT
+ * a switch; its inner class is collected directly by `findClassNamesInSelector`.
+ */
+export const isLocalSwitchItem = (item: AstRuleItem): boolean =>
+  item.type === 'PseudoClass' && item.name === 'local' && !item.argument;


### PR DESCRIPTION
Fixes #101.

## Problem

A `:local(...)` class nested inside a bare `:global {}` block was falsely reported as non-existent:

```scss
:global {
  :local(.small) {}
}
```

```tsx
import styles from './a.module.scss'
export const A = () => <div className={styles.small} />
```

`check-unused-css src` reported `.small` as *"used in source files but non-existent in CSS"*.

**Root cause:** A bare `:global {}` block scopes its descendants globally, so the extractor dropped every rule whose ancestor opened such a block (issue #91). But a `:local(...)` function form — or a bare `:local` switch — nested inside it re-scopes those classes back to local, and the whole-rule drop lost them.

## Fix

- `isInsideGlobalScope` now resolves scope by the **nearest switching ancestor**: a bare `:local` switch flips scope back to local, mirroring the existing `:global` handling. The function forms `:global(.foo)`/`:local(.foo)` are still not switches.
- A rule that stays in global scope no longer drops entirely — it contributes only the classes a `:local(...)` function form re-scopes to local, via the new `findLocalRescopedClassNames`. Plain classes inside `:global` stay global as before.
- A rule whose own selector opens a bare `:local` switch (`:local .scoped`) is extracted in full even inside a `:global` block.

## Tests

- `isInsideGlobalScope.test.ts` — nearest-switch-wins (`:local`/`:global` nesting), function-form-is-not-a-switch, plus `selectorHasLocalSwitch` unit coverage.
- `findClassNamesInSelector.test.ts` — `findLocalRescopedClassNames` unit coverage (function form only, plain dropped, `:global(...)` ignored, nested in `:not()`).
- `extractCssClasses.integration.test.ts` — real-pipeline block for issue #101: function form, bare `:local` switch, compound/double-dash, at-rule ancestor, plain-stays-global regression guards.
- e2e fixture `noError/LocalInGlobalBlock` reproducing the exact issue example.

`bun run check:all` passes (format, lint, type, 1104 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)